### PR TITLE
Fix: snapshots should create relations with database=none

### DIFF
--- a/dbt/include/spark/macros/materializations/snapshot.sql
+++ b/dbt/include/spark/macros/materializations/snapshot.sql
@@ -35,7 +35,7 @@
                                 
     {%- set tmp_relation = api.Relation.create(identifier=tmp_identifier,
                                                   schema=target_relation.schema,
-                                                  database=target_relation.database,
+                                                  database=none,
                                                   type='view') -%}
 
     {% set select = snapshot_staging_table(strategy, sql, target_relation) %}
@@ -90,7 +90,7 @@
   {% endif %}
 
   {% set target_relation_exists, target_relation = get_or_create_relation(
-          database=model.database,
+          database=none,
           schema=model.schema,
           identifier=target_table,
           type='table') -%}


### PR DESCRIPTION
### Problem

The `snapshot` materialization twice needs to get or make a relation. Previously, it set the `database` by grabbing the value of the existing/model relation's `database`. This resulting in an error:

```
hologram.ValidationError: Undefined is not of type 'string'

Failed validating 'type' in schema[0]:
    {'type': 'string'}

On instance:
    Undefined
```

### Solution

We should explicitly set `database=none`, in line with the changes in dbt-spark==0.17.0 that preclude `database` from having a value.

### Note on testing

I caught this in my local end-to-end testing of all current features. This wasn't caught in automated integration testing because:
* `dbt-integration-tests` suite does not include a `dbt snapshot` step
* snapshots are a Delta-only features, and current integration tests run only on dockerized Apache Spark

The resolution involves:
* better testing for plugins (https://github.com/fishtown-analytics/dbt/issues/2492)
* an additional set of tests for Delta-only features, on a Databricks runtime, that could run in parallel with standard feature testing on dockerized spark (#86)