### PR TITLE
Show more detailed feedback when pyodbc import fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - Add support for `merge_update_columns` config in `merge`-strategy incremental models ([#183](https://github.com/fishtown-analytics/dbt-spark/pull/183), ([#184](https://github.com/fishtown-analytics/dbt-spark/pull/184))
+- Add pyodbc import error message to dbt.exceptions.RuntimeException to get more detailed information when running `dbt debug` ([#192](https://github.com/dbt-labs/dbt-spark/pull/192))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- Add support for `merge_update_columns` config in `merge`-strategy incremental models ([#183](https://github.com/fishtown-analytics/dbt-spark/pull/183), ([#184](https://github.com/fishtown-analytics/dbt-spark/pull/184))
+- Add support for `merge_update_columns` config in `merge`-strategy incremental models ([#183](https://github.com/fishtown-analytics/dbt-spark/pull/183), [#184](https://github.com/fishtown-analytics/dbt-spark/pull/184))
 - Add pyodbc import error message to dbt.exceptions.RuntimeException to get more detailed information when running `dbt debug` ([#192](https://github.com/dbt-labs/dbt-spark/pull/192))
 
 ### Fixes

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -96,7 +96,7 @@ class SparkCredentials(Credentials):
 
         if self.method == SparkConnectionMethod.ODBC:
             try:
-                import pyodbc
+                import pyodbc    # noqa: F401
             except ImportError as e:
                 raise dbt.exceptions.RuntimeException(
                     f"{self.method} connection method requires "

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -90,7 +90,7 @@ class SparkCredentials(Credentials):
             )
         self.database = None
 
-        if self.method == SparkConnectionMethod.ODBC and pyodbc is None:
+        if self.method == SparkConnectionMethod.ODBC:
             try:
                 import pyodbc
             except ImportError as e:

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -16,6 +16,10 @@ except ImportError:
     ThriftState = None
     THttpClient = None
     hive = None
+try:
+    import pyodbc
+except ImportError:
+    pyodbc = None
 from datetime import datetime
 import sqlparams
 
@@ -376,8 +380,6 @@ class SparkConnectionManager(SQLConnectionManager):
                                             kerberos_service_name=creds.kerberos_service_name)  # noqa
                     handle = PyhiveConnectionWrapper(conn)
                 elif creds.method == SparkConnectionMethod.ODBC:
-                    import pyodbc
-
                     if creds.cluster is not None:
                         required_fields = ['driver', 'host', 'port', 'token',
                                            'organization', 'cluster']

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -102,7 +102,8 @@ class SparkCredentials(Credentials):
                     f"{self.method} connection method requires "
                     "additional dependencies. \n"
                     "Install the additional required dependencies with "
-                    "`pip install dbt-spark[ODBC]`"
+                    "`pip install dbt-spark[ODBC]`\n\n"
+                    f"ImportError({e.msg})"
                 ) from e
 
         if (


### PR DESCRIPTION
# Description

When `pydobc` can not be imported and the user specifies this connection method, we raise an error that the `dbt-spark[ODBC]` should be installed. However, it can also be that the package is installed, but that it still can not be imported. Then, the ImportError details useful information, like some ODBC image can not be found, which is resolved with installing `unixodb-dev`.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 