### PR TITLE
Support sql_header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ### Fixes
 - Fix `get_columns_in_relation` when called on models created in the same run ([#196](https://github.com/dbt-labs/dbt-spark/pull/196), [#197](https://github.com/dbt-labs/dbt-spark/pull/197))
+- Add support for [sql_header](https://docs.getdbt.com/reference/resource-configs/sql_header) ([#200](https://github.com/dbt-labs/dbt-spark/pull/200))
 
 ### Contributors
 - [@ali-tny](https://github.com/ali-tny) ([#197](https://github.com/fishtown-analytics/dbt-spark/pull/197))
+- [@jethron](https://github.com/jethron) ([#200](https://github.com/dbt-labs/dbt-spark/pull/200))
 
 ## dbt-spark 0.20.0 (July 12, 2021)
 

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -84,6 +84,9 @@
 {% endmacro %}
 
 {% macro spark__create_table_as(temporary, relation, sql) -%}
+  {%- set sql_header = config.get('sql_header', none) -%}
+  {{ sql_header if sql_header is not none }}
+
   {% if temporary -%}
     {{ create_temporary_view(relation, sql) }}
   {%- else -%}
@@ -105,6 +108,9 @@
 
 
 {% macro spark__create_view_as(relation, sql) -%}
+  {%- set sql_header = config.get('sql_header', none) -%}
+  {{ sql_header if sql_header is not none }}
+
   create or replace view {{ relation }}
   {{ comment_clause() }}
   as


### PR DESCRIPTION
### Description
Support preliminary setup queries when creating or merging tables/views.

As documented at https://docs.getdbt.com/reference/resource-configs/sql_header

I've tried to implement it in the same places it's supported for Snowflake and BigQuery already.

My use-case is I want to use Databricks' Delta support for [Automatic Schema Evolution](https://docs.databricks.com/delta/delta-update.html#automatic-schema-evolution) for individual models rather than cluster-wide. This needs setting `set spark.databricks.delta.schema.autoMerge.enabled=true`, which I can do using this feature (it doesn't work with just `pre_hooks`).



### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 