### PR TITLE
Add support for ODBC Server Side Parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ### Fixes
 - Add pyodbc import error message to dbt.exceptions.RuntimeException to get more detailed information when running `dbt debug` ([#192](https://github.com/dbt-labs/dbt-spark/pull/192))
+- Add support for ODBC Server Side Parameters, allowing options that need to be set with the `SET` statement to be used ([#201](https://github.com/dbt-labs/dbt-spark/pull/201))
 
 ### Contributors
 - [@JCZuurmond](https://github.com/JCZuurmond) ([#192](https://github.com/fishtown-analytics/dbt-spark/pull/192))
+- [@jethron](https://github.com/jethron) ([#201](https://github.com/fishtown-analytics/dbt-spark/pull/201))
 
 ## dbt-spark 0.21.0b1 (August 3, 2021)
 


### PR DESCRIPTION
### Description

Allow passing through Cluster Configuration parameters via `profiles.yml` when using the `odbc` connection method.
This allows configuration of values that would need to be set via [SET](https://spark.apache.org/docs/3.0.0-preview/sql-ref-syntax-aux-conf-mgmt-set.html) to be run in the Spark session and take effect on DBT models.

E.g.:

```yaml
spark_dbt:
  target: default
  outputs:
    default:
      type: spark
      method: odbc
      driver: /opt/simba/spark/lib/64/libsparkodbc_sb64.so
      schema: default
      host: [hostid]
      token: [token]
      cluster: [clusterid]
      port: 443
      connect_retries: 3
      connect_timeout: 20
      server_side_parameters:
          "spark.databricks.delta.schema.autoMerge.enabled": True
          "spark.sql.jsonGenerator.ignoreNullFields": True
```

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 