### PR TITLE
Feature/parse struct fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## dbt-spark 0.21.0 (Release TBD)
 
 ### Fixes
+- Parse properly columns when there are struct fields. 
 - Add pyodbc import error message to dbt.exceptions.RuntimeException to get more detailed information when running `dbt debug` ([#192](https://github.com/dbt-labs/dbt-spark/pull/192))
 - Add support for ODBC Server Side Parameters, allowing options that need to be set with the `SET` statement to be used ([#201](https://github.com/dbt-labs/dbt-spark/pull/201))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## dbt-spark 0.21.0 (Release TBD)
 
 ### Fixes
-- Parse properly columns when there are struct fields. 
+- Parse properly columns when there are struct fields to solve issue ([#202](https://github.com/dbt-labs/dbt-spark/issues/202))
 - Add pyodbc import error message to dbt.exceptions.RuntimeException to get more detailed information when running `dbt debug` ([#192](https://github.com/dbt-labs/dbt-spark/pull/192))
 - Add support for ODBC Server Side Parameters, allowing options that need to be set with the `SET` statement to be used ([#201](https://github.com/dbt-labs/dbt-spark/pull/201))
 

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -64,7 +64,7 @@ class SparkAdapter(SQLAdapter):
         'stats:rows:include',
     )
     INFORMATION_COLUMNS_REGEX = re.compile(
-        r"\|-- (.*): (.*) \(nullable = (.*)\b", re.MULTILINE)
+        r"^ \|-- (.*): (.*) \(nullable = (.*)\b", re.MULTILINE)
     INFORMATION_OWNER_REGEX = re.compile(r"^Owner: (.*)$", re.MULTILINE)
     INFORMATION_STATISTICS_REGEX = re.compile(
         r"^Statistics: (.*)$", re.MULTILINE)

--- a/test/unit/test_adapter.py
+++ b/test/unit/test_adapter.py
@@ -563,7 +563,7 @@ class TestSparkAdapter(unittest.TestCase):
             'table_owner': 'root',
             'column': 'struct_col',
             'column_index': 3,
-            'dtype': 'struct<struct_inner_col:string>',
+            'dtype': 'struct',
             'numeric_scale': None,
             'numeric_precision': None,
             'char_size': None,

--- a/test/unit/test_adapter.py
+++ b/test/unit/test_adapter.py
@@ -646,12 +646,7 @@ class TestSparkAdapter(unittest.TestCase):
             'dtype': 'struct',
             'numeric_scale': None,
             'numeric_precision': None,
-            'char_size': None,
-
-            'stats:bytes:description': '',
-            'stats:bytes:include': True,
-            'stats:bytes:label': 'bytes',
-            'stats:bytes:value': 123456789,
+            'char_size': None
         })
 
     def test_parse_columns_from_information_with_table_type_and_parquet_provider(self):

--- a/test/unit/test_adapter.py
+++ b/test/unit/test_adapter.py
@@ -351,7 +351,7 @@ class TestSparkAdapter(unittest.TestCase):
             'table_owner': 'root',
             'column': 'struct_col',
             'column_index': 3,
-            'dtype': 'struct',
+            'dtype': 'struct<struct_inner_col:string>',
             'numeric_scale': None,
             'numeric_precision': None,
             'char_size': None
@@ -563,7 +563,7 @@ class TestSparkAdapter(unittest.TestCase):
             'table_owner': 'root',
             'column': 'struct_col',
             'column_index': 3,
-            'dtype': 'struct',
+            'dtype': 'struct<struct_inner_col:string>',
             'numeric_scale': None,
             'numeric_precision': None,
             'char_size': None,

--- a/test/unit/test_adapter.py
+++ b/test/unit/test_adapter.py
@@ -300,7 +300,7 @@ class TestSparkAdapter(unittest.TestCase):
         config = self._get_target_http(self.project_cfg)
         rows = SparkAdapter(config).parse_describe_extended(
             relation, input_cols)
-        self.assertEqual(len(rows), 3)
+        self.assertEqual(len(rows), 4)
         self.assertEqual(rows[0].to_column_dict(omit_none=False), {
             'table_database': None,
             'table_schema': relation.schema,

--- a/test/unit/test_adapter.py
+++ b/test/unit/test_adapter.py
@@ -275,6 +275,7 @@ class TestSparkAdapter(unittest.TestCase):
             ('col1', 'decimal(22,0)'),
             ('col2', 'string',),
             ('dt', 'date'),
+            ('struct_col', 'struct<struct_inner_col:string>')
             ('# Partition Information', 'data_type'),
             ('# col_name', 'data_type'),
             ('dt', 'date'),
@@ -337,6 +338,20 @@ class TestSparkAdapter(unittest.TestCase):
             'column': 'dt',
             'column_index': 2,
             'dtype': 'date',
+            'numeric_scale': None,
+            'numeric_precision': None,
+            'char_size': None
+        })
+
+        self.assertEqual(rows[3].to_column_dict(omit_none=False), {
+            'table_database': None,
+            'table_schema': relation.schema,
+            'table_name': relation.name,
+            'table_type': rel_type,
+            'table_owner': 'root',
+            'column': 'struct_col',
+            'column_index': 3,
+            'dtype': 'struct',
             'numeric_scale': None,
             'numeric_precision': None,
             'char_size': None
@@ -507,6 +522,8 @@ class TestSparkAdapter(unittest.TestCase):
             " |-- col1: decimal(22,0) (nullable = true)\n"
             " |-- col2: string (nullable = true)\n"
             " |-- dt: date (nullable = true)\n"
+            " |-- struct_col: struct (nullable = true)\n"
+            " |    |-- struct_inner_col: string (nullable = true)\n"
         )
         relation = SparkRelation.create(
             schema='default_schema',
@@ -518,7 +535,7 @@ class TestSparkAdapter(unittest.TestCase):
         config = self._get_target_http(self.project_cfg)
         columns = SparkAdapter(config).parse_columns_from_information(
             relation)
-        self.assertEqual(len(columns), 3)
+        self.assertEqual(len(columns), 4)
         self.assertEqual(columns[0].to_column_dict(omit_none=False), {
             'table_database': None,
             'table_schema': relation.schema,
@@ -528,6 +545,25 @@ class TestSparkAdapter(unittest.TestCase):
             'column': 'col1',
             'column_index': 0,
             'dtype': 'decimal(22,0)',
+            'numeric_scale': None,
+            'numeric_precision': None,
+            'char_size': None,
+
+            'stats:bytes:description': '',
+            'stats:bytes:include': True,
+            'stats:bytes:label': 'bytes',
+            'stats:bytes:value': 123456789,
+        })
+
+        self.assertEqual(columns[3].to_column_dict(omit_none=False), {
+            'table_database': None,
+            'table_schema': relation.schema,
+            'table_name': relation.name,
+            'table_type': rel_type,
+            'table_owner': 'root',
+            'column': 'struct_col',
+            'column_index': 3,
+            'dtype': 'struct',
             'numeric_scale': None,
             'numeric_precision': None,
             'char_size': None,
@@ -571,6 +607,8 @@ class TestSparkAdapter(unittest.TestCase):
             " |-- col1: decimal(22,0) (nullable = true)\n"
             " |-- col2: string (nullable = true)\n"
             " |-- dt: date (nullable = true)\n"
+            " |-- struct_col: struct (nullable = true)\n"
+            " |    |-- struct_inner_col: string (nullable = true)\n"
         )
         relation = SparkRelation.create(
             schema='default_schema',
@@ -582,7 +620,7 @@ class TestSparkAdapter(unittest.TestCase):
         config = self._get_target_http(self.project_cfg)
         columns = SparkAdapter(config).parse_columns_from_information(
             relation)
-        self.assertEqual(len(columns), 3)
+        self.assertEqual(len(columns), 4)
         self.assertEqual(columns[1].to_column_dict(omit_none=False), {
             'table_database': None,
             'table_schema': relation.schema,
@@ -595,6 +633,25 @@ class TestSparkAdapter(unittest.TestCase):
             'numeric_scale': None,
             'numeric_precision': None,
             'char_size': None
+        })
+
+        self.assertEqual(columns[3].to_column_dict(omit_none=False), {
+            'table_database': None,
+            'table_schema': relation.schema,
+            'table_name': relation.name,
+            'table_type': rel_type,
+            'table_owner': 'root',
+            'column': 'struct_col',
+            'column_index': 3,
+            'dtype': 'struct',
+            'numeric_scale': None,
+            'numeric_precision': None,
+            'char_size': None,
+
+            'stats:bytes:description': '',
+            'stats:bytes:include': True,
+            'stats:bytes:label': 'bytes',
+            'stats:bytes:value': 123456789,
         })
 
     def test_parse_columns_from_information_with_table_type_and_parquet_provider(self):
@@ -619,6 +676,8 @@ class TestSparkAdapter(unittest.TestCase):
             " |-- col1: decimal(22,0) (nullable = true)\n"
             " |-- col2: string (nullable = true)\n"
             " |-- dt: date (nullable = true)\n"
+            " |-- struct_col: struct (nullable = true)\n"
+            " |    |-- struct_inner_col: string (nullable = true)\n"
         )
         relation = SparkRelation.create(
             schema='default_schema',
@@ -630,7 +689,7 @@ class TestSparkAdapter(unittest.TestCase):
         config = self._get_target_http(self.project_cfg)
         columns = SparkAdapter(config).parse_columns_from_information(
             relation)
-        self.assertEqual(len(columns), 3)
+        self.assertEqual(len(columns), 4)
         self.assertEqual(columns[2].to_column_dict(omit_none=False), {
             'table_database': None,
             'table_schema': relation.schema,
@@ -640,6 +699,30 @@ class TestSparkAdapter(unittest.TestCase):
             'column': 'dt',
             'column_index': 2,
             'dtype': 'date',
+            'numeric_scale': None,
+            'numeric_precision': None,
+            'char_size': None,
+
+            'stats:bytes:description': '',
+            'stats:bytes:include': True,
+            'stats:bytes:label': 'bytes',
+            'stats:bytes:value': 1234567890,
+
+            'stats:rows:description': '',
+            'stats:rows:include': True,
+            'stats:rows:label': 'rows',
+            'stats:rows:value': 12345678
+        })
+
+        self.assertEqual(columns[3].to_column_dict(omit_none=False), {
+            'table_database': None,
+            'table_schema': relation.schema,
+            'table_name': relation.name,
+            'table_type': rel_type,
+            'table_owner': 'root',
+            'column': 'struct_col',
+            'column_index': 3,
+            'dtype': 'struct',
             'numeric_scale': None,
             'numeric_precision': None,
             'char_size': None,

--- a/test/unit/test_adapter.py
+++ b/test/unit/test_adapter.py
@@ -275,7 +275,7 @@ class TestSparkAdapter(unittest.TestCase):
             ('col1', 'decimal(22,0)'),
             ('col2', 'string',),
             ('dt', 'date'),
-            ('struct_col', 'struct<struct_inner_col:string>')
+            ('struct_col', 'struct<struct_inner_col:string>'),
             ('# Partition Information', 'data_type'),
             ('# col_name', 'data_type'),
             ('dt', 'date'),


### PR DESCRIPTION
resolves #202

<!---
Resolves #202 
-->


### Description

The issue was when parsing the schema, the current regex deal with inner struct fields as root fields, hence causing an error later because the column was not found (check issue #202 for a more detailed description)


Current one: 
<img width="437" alt="image" src="https://user-images.githubusercontent.com/15931770/129523468-b71aac40-77b5-490b-a8d1-41c7f3d935bb.png">

Proposed one:

<img width="461" alt="image" src="https://user-images.githubusercontent.com/15931770/129523521-2cad7e19-17e0-4fdf-bae5-f0a6ad8b46d9.png">


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests (Modifyed)
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section. (Not sure if I did this right, let me know if it's something else to improve)
 