### PR TITLE
Bump `main` version to 0.21.0

### DIFF
--- a/.bumpversion-dbt.cfg
+++ b/.bumpversion-dbt.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.20.0rc2
+current_version = 0.21.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.20.0rc2
+current_version = 0.21.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/dbt/adapters/spark/__version__.py
+++ b/dbt/adapters/spark/__version__.py
@@ -1,1 +1,1 @@
-version = "0.20.0rc2"
+version = "0.21.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dbt-core==0.20.0rc2
+dbt-core==0.21.0
 PyHive[hive]>=0.6.0,<0.7.0
 pyodbc>=4.0.30
 sqlparams>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ def _dbt_spark_version():
 package_version = _dbt_spark_version()
 description = """The SparkSQL plugin for dbt (data build tool)"""
 
-dbt_version = '0.20.0rc2'
+dbt_version = '0.21.0'
 # the package version should be the dbt version, with maybe some things on the
-# ends of it. (0.20.0rc2 vs 0.20.0rc2a1, 0.20.0rc2.1, ...)
+# ends of it. (0.21.0 vs 0.21.0a1, 0.21.0.1, ...)
 if not package_version.startswith(dbt_version):
     raise ValueError(
         f'Invalid setup.py: package_version={package_version} must start with '


### PR DESCRIPTION
Port https://github.com/dbt-labs/dbt-spark/commit/143c39af7fba48c7666e2d406e7d98701588b36a to `main`

This will at least unblock #229, while we continue to work through pre-v1 readiness (#227)