### PR TITLE
Fire events in tests.integration.base instead of AdapterLogger

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -27,10 +27,13 @@ from dbt.logger import log_manager
 from dbt.events.functions import (
     capture_stdout_logs, fire_event, setup_event_logger, stop_capture_stdout_logs
 )
-from dbt.events import AdapterLogger
+from dbt.events.test_types import (
+    IntegrationTestInfo,
+    IntegrationTestDebug,
+    IntegrationTestException
+)
 from dbt.contracts.graph.manifest import Manifest
 
-logger = AdapterLogger("Spark")
 
 INITIAL_ROOT = os.getcwd()
 
@@ -290,7 +293,7 @@ class DBTIntegrationTest(unittest.TestCase):
                 'test_original_source_path={0.test_original_source_path}',
                 'test_root_dir={0.test_root_dir}'
             )).format(self)
-            logger.exception(msg)
+            fire_event(IntegrationTestException(msg=msg))
 
             # if logging isn't set up, I still really want this message.
             print(msg)
@@ -400,8 +403,8 @@ class DBTIntegrationTest(unittest.TestCase):
         try:
             shutil.rmtree(self.test_root_dir)
         except EnvironmentError:
-            logger.exception('Could not clean up after test - {} not removable'
-                             .format(self.test_root_dir))
+            msg = f"Could not clean up after test - {self.test_root_dir} not removable"
+            fire_event(IntegrationTestException(msg=msg))
 
     def _get_schema_fqn(self, database, schema):
         schema_fqn = self.quote_as_configured(schema, 'schema')
@@ -471,7 +474,8 @@ class DBTIntegrationTest(unittest.TestCase):
             final_args.extend(['--profiles-dir', self.test_root_dir])
         final_args.append('--log-cache-events')
 
-        logger.info("Invoking dbt with {}".format(final_args))
+        msg = f"Invoking dbt with {final_args}"
+        fire_event(IntegrationTestInfo(msg=msg))
         return dbt.handle_and_check(final_args)
 
     def run_sql_file(self, path, kwargs=None):


### PR DESCRIPTION
Make the same change here as in https://github.com/dbt-labs/dbt-redshift/pull/43

Integration tests haven't been failing nightly, only because they haven't been running nightly—they're still running in CircleCI and not yet GitHub Actions (#244)