### PR TITLE
Bump version to 1.0.0rc2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0rc1
+current_version = 1.0.0rc2
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## dbt-spark 1.0.0 (Release TBD)
 
+## dbt-spark 1.0.0rc2 (November 24, 2021)
+
 ### Features
 - Add support for Apache Hudi (hudi file format) which supports incremental merge strategies ([#187](https://github.com/dbt-labs/dbt-spark/issues/187), [#210](https://github.com/dbt-labs/dbt-spark/pull/210))
 

--- a/dbt/adapters/spark/__version__.py
+++ b/dbt/adapters/spark/__version__.py
@@ -1,1 +1,1 @@
-version = "1.0.0rc1"
+version = "1.0.0rc2"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -15,7 +15,6 @@ flaky>=3.5.3,<4
 pytest-csv
 
 # Test requirements
-#pytest-dbt-adapter==0.5.1 
-git+https://github.com/dbt-labs/dbt-adapter-tests.git#egg=pytest-dbt-adapter
+pytest-dbt-adapter==0.6.0
 sasl==0.2.1
 thrift_sasl==0.4.1


### PR DESCRIPTION
The automated workflow runs into dependency issues: https://github.com/dbt-labs/dbt-spark/actions/runs/1491887246. (I don't think we actually need all those dependencies in `dev_requirements.txt`.)

So, still me for now :)