### PR TITLE
Corrected definition for set full_refresh_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## dbt-spark 1.0.0 (Release TBD)
 
 ### Fixes
-- ```dbt run --full-refresh``` corrected to respect config that overrides full_refresh = False. As explained in [issue 260](https://github.com/dbt-labs/dbt-spark/issues/260), the current incremental implementation only uses the FULL_REFRESH flag, unlike the implementation in dbt-code/dbt-snowflake, etc.
+- Incremental materialization corrected to respect `full_refresh` config, by using `should_full_refresh()` macro ([#260](https://github.com/dbt-labs/dbt-spark/issues/260), [#262](https://github.com/dbt-labs/dbt-spark/pull/262/))
 
 ### Contributors
-- [@grindheim](https://github.com/grindheim) ([#260](https://github.com/dbt-labs/dbt-spark/pull/262/)
+- [@grindheim](https://github.com/grindheim) ([#262](https://github.com/dbt-labs/dbt-spark/pull/262/))
 
 ## dbt-spark 1.0.0rc2 (November 24, 2021)
 
@@ -25,12 +25,6 @@
 - Add support for structured logging ([#251](https://github.com/dbt-labs/dbt-spark/pull/251))
 
 ## dbt-spark 0.21.1 (Release TBD)
-
-### Fixes
-- ```dbt run --full-refresh``` corrected to respect config that overrides full_refresh = False. As explained in [issue 260](https://github.com/dbt-labs/dbt-spark/issues/260), the current incremental implementation only uses the FULL_REFRESH flag, unlike the implementation in dbt-code/dbt-snowflake, etc.
-
-### Contributors
-- [@grindheim](https://github.com/grindheim) ([#260](https://github.com/dbt-labs/dbt-spark/pull/262/)
 
 ## dbt-spark 0.21.1rc1 (November 3, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## dbt-spark 1.0.0 (Release TBD)
 
+### Fixes
+- ```dbt run --full-refresh``` corrected to respect config that overrides full_refresh = False. As explained in [issue 260](https://github.com/dbt-labs/dbt-spark/issues/260), the current incremental implementation only uses the FULL_REFRESH flag, unlike the implementation in dbt-code/dbt-snowflake, etc.
+
+### Contributors
+- [@grindheim](https://github.com/grindheim) ([#260](https://github.com/dbt-labs/dbt-spark/pull/262/)
+
 ## dbt-spark 1.0.0rc2 (November 24, 2021)
 
 ### Features
@@ -19,6 +25,12 @@
 - Add support for structured logging ([#251](https://github.com/dbt-labs/dbt-spark/pull/251))
 
 ## dbt-spark 0.21.1 (Release TBD)
+
+### Fixes
+- ```dbt run --full-refresh``` corrected to respect config that overrides full_refresh = False. As explained in [issue 260](https://github.com/dbt-labs/dbt-spark/issues/260), the current incremental implementation only uses the FULL_REFRESH flag, unlike the implementation in dbt-code/dbt-snowflake, etc.
+
+### Contributors
+- [@grindheim](https://github.com/grindheim) ([#260](https://github.com/dbt-labs/dbt-spark/pull/262/)
 
 ## dbt-spark 0.21.1rc1 (November 3, 2021)
 

--- a/dbt/include/spark/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/spark/macros/materializations/incremental/incremental.sql
@@ -10,7 +10,7 @@
   {%- set unique_key = config.get('unique_key', none) -%}
   {%- set partition_by = config.get('partition_by', none) -%}
 
-  {%- set full_refresh_mode = (flags.FULL_REFRESH == True) -%}
+  {%- set full_refresh_mode = (should_full_refresh()) -%}
   
   {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}
 


### PR DESCRIPTION
resolves #260

### Description

The current definition of the file ```dbt-spark\dbt\include\spark\macros\materializations\incremental\incremental.sql``` has an errouneous implementation of ```set full_refresh_mode``` that does not take into consideration the definition that is set in the config.

This PR corrects this issue by replacing it with the implementation in dbt-core/dbt-snowflake/etc.

As this PR only brings dbt-spark in sync with the other repos, and it's only one line of code, I figured tests are not relevant for this PR.

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.