### PR TITLE
`get_response` -> `AdapterResponse`

### DIFF
--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 import dbt.exceptions
 from dbt.adapters.base import Credentials
 from dbt.adapters.sql import SQLConnectionManager
-from dbt.contracts.connection import ConnectionState
+from dbt.contracts.connection import ConnectionState, AdapterResponse
 from dbt.events import AdapterLogger
 from dbt.utils import DECIMALS
 from dbt.adapters.spark import __version__
@@ -304,8 +304,12 @@ class SparkConnectionManager(SQLConnectionManager):
         connection.handle.cancel()
 
     @classmethod
-    def get_response(cls, cursor):
-        return 'OK'
+    def get_response(cls, cursor) -> AdapterResponse:
+        # until we do this better: https://github.com/dbt-labs/dbt-spark/issues/142
+        message = 'OK'
+        return AdapterResponse(
+            _message=message
+        )
 
     # No transactions on Spark....
     def add_begin_query(self, *args, **kwargs):

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -305,7 +305,7 @@ class SparkConnectionManager(SQLConnectionManager):
 
     @classmethod
     def get_response(cls, cursor) -> AdapterResponse:
-        # until we do this better: https://github.com/dbt-labs/dbt-spark/issues/142
+        # https://github.com/dbt-labs/dbt-spark/issues/142
         message = 'OK'
         return AdapterResponse(
             _message=message


### PR DESCRIPTION
In `core.dbt.adapters.sql.connection`, we:
- Say that `get_response` is an abstract method which can return `Union[AdapterResponse, str]`
- Expect an `AdapterResponse` (an object with a `_message` attribute) when we fire [`SQLQueryStatus`](https://github.com/dbt-labs/dbt-core/blob/9ed9936c84ef5a2706ad15f9757fb83a9c14139b/core/dbt/adapters/sql/connections.py#L78), ever since https://github.com/dbt-labs/dbt-core/commit/b3039fdc7629b5027096e92ed9b7612419cf3fea

Before this change, `dbt-spark` implemented `get_response` in a super naive way (it just returns a string). This PR changes it to return an `AdapterResponse` instead, with no functional change.

In `dbt-core`, we should either:
- Check the type of the value returned by `get_response`, then either use it `_message` attribute (if `AdapterResponse`) or itself (if `str`)
- Enforce that the `get_response` abstract method must return an `AdapterResponse` — not a bad change, and it's _effectively_ true, but we should think about waiting for a minor version release with clearer communication ahead of time