### PR TITLE
Fixing version bumping issues

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,30 +1,27 @@
 [bumpversion]
-current_version = 1.0.0rc2
+current_version = 1.0.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
-	(\.(?P<pluginpatch>\d+))?
-	((?P<prerelease>[a-z]+)(?P<num>\d+))?
+	((?P<prerelease>a|b|rc)(?P<num>\d+))?
 serialize = 
-	{major}.{minor}.{patch}.{pluginpatch}{prerelease}{num}
 	{major}.{minor}.{patch}{prerelease}{num}
-	{major}.{minor}.{patch}.{pluginpatch}
 	{major}.{minor}.{patch}
 commit = False
 tag = False
 
 [bumpversion:part:prerelease]
 first_value = a
+optional_value = final
 values = 
 	a
 	b
 	rc
+	final
 
 [bumpversion:part:num]
 first_value = 1
 
-[bumpversion:part:pluginpatch]
-first_value = 1
+[bumpversion:file:setup.py]
 
 [bumpversion:file:dbt/adapters/spark/__version__.py]
-

--- a/dbt/adapters/spark/__version__.py
+++ b/dbt/adapters/spark/__version__.py
@@ -1,1 +1,1 @@
-version = "1.0.0rc2"
+version = "1.0.0"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 import sys
 import re
 
-# require python 3.6 or newer
+# require python 3.7 or newer
 if sys.version_info < (3, 7):
     print('Error: dbt does not support this version of Python.')
     print('Please upgrade to Python 3.7 or higher.')
@@ -43,11 +43,6 @@ def _get_plugin_version_dict():
         return match.groupdict()
 
 
-def _get_plugin_version():
-    parts = _get_plugin_version_dict()
-    return "{major}.{minor}.{patch}{prekind}{pre}".format(**parts)
-
-
 # require a compatible minor version (~=), prerelease if this is a prerelease
 def _get_dbt_core_version():
     parts = _get_plugin_version_dict()
@@ -57,7 +52,7 @@ def _get_dbt_core_version():
 
 
 package_name = "dbt-spark"
-package_version = _get_plugin_version()
+package_version = "1.0.0"
 dbt_core_version = _get_dbt_core_version()
 description = """The Apache Spark adapter plugin for dbt"""
 


### PR DESCRIPTION
### Description

Fixing up version bumping script to match the other adapters. Removed some unneeded logic and updated to be on `1.0.0`

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.