### PR TITLE
[Backport] #285 to `1.0.latest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## dbt-spark 1.0.1rc0 (Release TBD)
+## dbt-spark 1.0.1rc1 (Release TBD)
 
 ### Fixes
 - Closes the connection properly ([#280](https://github.com/dbt-labs/dbt-spark/issues/280), [#285](https://github.com/dbt-labs/dbt-spark/pull/285))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## dbt-spark 1.0.1rc0 (Release TBD)
+
+### Fixes
+- Closes the connection properly ([#280](https://github.com/dbt-labs/dbt-spark/issues/280), [#285](https://github.com/dbt-labs/dbt-spark/pull/285))
+
+### Contributors
+- [@ueshin](https://github.com/ueshin) ([#285](https://github.com/dbt-labs/dbt-spark/pull/285))
+
 ## dbt-spark 1.0.0 (Release TBD)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Contributors
 - [@ueshin](https://github.com/ueshin) ([#285](https://github.com/dbt-labs/dbt-spark/pull/285))
 
-## dbt-spark 1.0.0 (Release TBD)
+## dbt-spark 1.0.0 (December 3, 2021)
 
 ### Fixes
 - Incremental materialization corrected to respect `full_refresh` config, by using `should_full_refresh()` macro ([#260](https://github.com/dbt-labs/dbt-spark/issues/260), [#262](https://github.com/dbt-labs/dbt-spark/pull/262/))

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -179,6 +179,7 @@ class PyhiveConnectionWrapper(object):
                 logger.debug(
                     "Exception while closing cursor: {}".format(exc)
                 )
+        self.handle.close()
 
     def rollback(self, *args, **kwargs):
         logger.debug("NotImplemented: rollback")


### PR DESCRIPTION
This closes connections after use, fixing an issue whereby clusters may not auto-terminate after a dbt run completes, with significant cost implications.

I believe we ought to include this fix in a `dbt-spark==1.0.1` patch release. We can first cut v1.0.1-rc1, for testing locally + in dbt Cloud (will be automatically included in the `v1.0.x (PRERELEASE patch - fixes only)` runtime image). Since the PR was merged into `main`, it will already be available in `development (HEAD)` later today.

Details in https://github.com/dbt-labs/dbt-spark/issues/280
Mirrors the change in https://github.com/databricks/dbt-databricks/pull/37