### PR TITLE
Configure insert_overwrite models to use parquet

### DIFF
--- a/tests/integration/incremental_strategies/models_insert_overwrite/insert_overwrite_no_partitions.sql
+++ b/tests/integration/incremental_strategies/models_insert_overwrite/insert_overwrite_no_partitions.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'insert_overwrite',
+    file_format = 'parquet',
 ) }}
 
 {% if not is_incremental() %}


### PR DESCRIPTION
Fixes failing test by configuring the model to materialize with the parquet file format, rather than the default (text). Otherwise, Databricks throws this error:
```
Syntax or semantic analysis error thrown in server while executing query. Error message from server: org.apache.hive.service.cli.HiveSQLException: Error running query: org.apache.spark.sql.AnalysisException: Table test16478710494709547255_incremental_strategies.insert_overwrite_no_partitions does not support dynamic overwrite in batch mode
```

Notes:
- It looks like this was failing on `main` a month ago! https://github.com/dbt-labs/dbt-spark/commit/d7f1d38d0dcf272dc0e513db4eeada0c08c407f5, [circleci run](https://app.circleci.com/pipelines/github/dbt-labs/dbt-spark/779/workflows/90b66a0d-cc95-4548-a7fe-e59521add964/jobs/2495), 
- I also ran into it while testing the cutover to our new Databricks workspace [circleci run](https://app.circleci.com/pipelines/github/dbt-labs/dbt-spark/779/workflows/90b66a0d-cc95-4548-a7fe-e59521add964/jobs/2495)
- Is this due to a newer Spark / Databricks Runtime version? Maybe