### PR TITLE
`1.0.1rc1` version bump miss

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,28 +3,25 @@ current_version = 1.0.1rc1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
-	(\.(?P<pluginpatch>\d+))?
-	((?P<prerelease>[a-z]+)(?P<num>\d+))?
+	((?P<prerelease>a|b|rc)(?P<num>\d+))?
 serialize = 
-	{major}.{minor}.{patch}.{pluginpatch}{prerelease}{num}
 	{major}.{minor}.{patch}{prerelease}{num}
-	{major}.{minor}.{patch}.{pluginpatch}
 	{major}.{minor}.{patch}
 commit = False
 tag = False
 
 [bumpversion:part:prerelease]
 first_value = a
+optional_value = final
 values = 
 	a
 	b
 	rc
+	final
 
 [bumpversion:part:num]
 first_value = 1
 
-[bumpversion:part:pluginpatch]
-first_value = 1
+[bumpversion:file:setup.py]
 
 [bumpversion:file:dbt/adapters/spark/__version__.py]
-

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -25,3 +25,4 @@ first_value = 1
 [bumpversion:file:setup.py]
 
 [bumpversion:file:dbt/adapters/spark/__version__.py]
+

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 import sys
 import re
 
-# require python 3.6 or newer
+# require python 3.7 or newer
 if sys.version_info < (3, 7):
     print('Error: dbt does not support this version of Python.')
     print('Please upgrade to Python 3.7 or higher.')
@@ -41,11 +41,6 @@ def _get_plugin_version_dict():
         if match is None:
             raise ValueError(f'invalid version at {_version_path}')
         return match.groupdict()
-
-
-def _get_plugin_version():
-    parts = _get_plugin_version_dict()
-    return "{major}.{minor}.{patch}{prekind}{pre}".format(**parts)
 
 
 # require a compatible minor version (~=), prerelease if this is a prerelease

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ def _get_dbt_core_version():
 
 # TODO remove old logic and add to versionBump script
 package_name = "dbt-spark"
-package_version = "1.0.0"
+package_version = "1.0.1rc1"
 dbt_core_version = _get_dbt_core_version()
 description = """The Apache Spark adapter plugin for dbt"""
 


### PR DESCRIPTION
### Description
This backport was missed #271 which caused the version bump script to miss a file. This is the backport plus the missed version bump

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.