### PR TITLE
CI ergonomics: connection retries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ jobs:
   integration-spark-databricks-http:
     environment:
       DBT_INVOCATION_ENV: circle
+      DBT_DATABRICKS_RETRY_ALL: True
     docker:
       - image: fishtownanalytics/test-container:10
     steps:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,8 +42,8 @@ def apache_spark_target():
         "user": "dbt",
         "method": "thrift",
         "port": 10000,
-        "connect_retries": 5,
-        "connect_timeout": 60,
+        "connect_retries": 3,
+        "connect_timeout": 5,
         "retry_all": True,
     }
 
@@ -57,6 +57,9 @@ def databricks_cluster_target():
         "token": os.getenv("DBT_DATABRICKS_TOKEN"),
         "driver": os.getenv("ODBC_DRIVER"),
         "port": 443,
+        "connect_retries": 3,
+        "connect_timeout": 5,
+        "retry_all": True,
     }
 
 
@@ -69,6 +72,9 @@ def databricks_sql_endpoint_target():
         "token": os.getenv("DBT_DATABRICKS_TOKEN"),
         "driver": os.getenv("ODBC_DRIVER"),
         "port": 443,
+        "connect_retries": 3,
+        "connect_timeout": 5,
+        "retry_all": True,
     }
 
 
@@ -80,8 +86,11 @@ def databricks_http_cluster_target():
         "token": os.getenv('DBT_DATABRICKS_TOKEN'),
         "method": "http",
         "port": 443,
+        # more retries + longer timout to handle unavailability while cluster is restarting
+        # return failures quickly in dev, retry all failures in CI (up to 5 min)
         "connect_retries": 5,
-        "connect_timeout": 60,
+        "connect_timeout": 60, 
+        "retry_all": bool(os.getenv('DBT_DATABRICKS_RETRY_ALL', False)),
     }
 
 

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -13,7 +13,7 @@ from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCo
 from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
 
 
-@pytest.mark.skip_profile('databricks_sql_endpoint', 'spark_session')
+@pytest.mark.skip_profile('spark_session')
 class TestSimpleMaterializationsSpark(BaseSimpleMaterializations):
     pass
 
@@ -33,12 +33,12 @@ class TestEmptySpark(BaseEmpty):
     pass
 
 
-@pytest.mark.skip_profile('databricks_sql_endpoint', 'spark_session')
+@pytest.mark.skip_profile('spark_session')
 class TestEphemeralSpark(BaseEphemeral):
     pass
 
 
-@pytest.mark.skip_profile('databricks_sql_endpoint', 'spark_session')
+@pytest.mark.skip_profile('spark_session')
 class TestIncrementalSpark(BaseIncremental):
     pass
 

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -160,8 +160,9 @@ class DBTIntegrationTest(unittest.TestCase):
                         'user': 'dbt',
                         'method': 'thrift',
                         'port': 10000,
-                        'connect_retries': 5,
-                        'connect_timeout': 60,
+                        'connect_retries': 3,
+                        'connect_timeout': 5,
+                        'retry_all': True,
                         'schema': self.unique_schema()
                     },
                 },
@@ -184,6 +185,9 @@ class DBTIntegrationTest(unittest.TestCase):
                         'token': os.getenv('DBT_DATABRICKS_TOKEN'),
                         'driver': os.getenv('ODBC_DRIVER'),
                         'port': 443,
+                        'connect_retries': 3,
+                        'connect_timeout': 5,
+                        'retry_all': True,
                         'schema': self.unique_schema()
                     },
                 },
@@ -206,6 +210,9 @@ class DBTIntegrationTest(unittest.TestCase):
                         'token': os.getenv('DBT_DATABRICKS_TOKEN'),
                         'driver': os.getenv('ODBC_DRIVER'),
                         'port': 443,
+                        'connect_retries': 3,
+                        'connect_timeout': 5,
+                        'retry_all': True,
                         'schema': self.unique_schema()
                     },
                 },

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 
 [testenv:integration-spark-databricks-http]
 basepython = python3.8
-commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_http_cluster tests/functional/adapter/test_basic.py'
+commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_http_cluster {posargs} -n4 tests/functional/adapter/test_basic.py'
 passenv = DBT_* PYTEST_ADDOPTS
 deps =
     -r{toxinidir}/requirements.txt
@@ -29,7 +29,7 @@ deps =
 
 [testenv:integration-spark-databricks-odbc-cluster]
 basepython = python3.8
-commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_cluster tests/functional/adapter/test_basic.py'
+commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_cluster {posargs} -n4 tests/functional/adapter/test_basic.py'
            /bin/bash -c '{envpython} -m pytest -v -m profile_databricks_cluster {posargs} -n4 tests/integration/*'
 passenv = DBT_* PYTEST_ADDOPTS ODBC_DRIVER
 deps =
@@ -39,7 +39,7 @@ deps =
 
 [testenv:integration-spark-databricks-odbc-sql-endpoint]
 basepython = python3.8
-commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_sql_endpoint tests/functional/adapter/test_basic.py'
+commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_sql_endpoint {posargs} -n4 tests/functional/adapter/test_basic.py'
            /bin/bash -c '{envpython} -m pytest -v -m profile_databricks_sql_endpoint {posargs} -n4 tests/integration/*'
 passenv = DBT_* PYTEST_ADDOPTS ODBC_DRIVER
 deps =
@@ -50,7 +50,7 @@ deps =
 
 [testenv:integration-spark-thrift]
 basepython = python3.8
-commands = /bin/bash -c '{envpython} -m pytest -v --profile apache_spark tests/functional/adapter/test_basic.py'
+commands = /bin/bash -c '{envpython} -m pytest -v --profile apache_spark {posargs} -n4 tests/functional/adapter/test_basic.py'
            /bin/bash -c '{envpython} -m pytest -v -m profile_apache_spark {posargs} -n4 tests/integration/*'
 passenv = DBT_* PYTEST_ADDOPTS
 deps =


### PR DESCRIPTION
resolves #326

### Description

- Turn on `retry_all` for all connection methods in CI
- 3 retries, 5 seconds apart, for most connection methods
- 5 retries, 60 seconds apart, for `http` — this needs to handle downtime while cluster restarts, and that can take several minutes. As such, turn on `retry_all` in CI, but turn it off by default for local dev/testing. Better to have intermittent failures in dev than a 5 min delay.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- ~I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.~