### PR TITLE
Add method to _connection_keys

### DIFF
--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -155,7 +155,7 @@ class SparkCredentials(Credentials):
         return self.host
 
     def _connection_keys(self):
-        return ('host', 'port', 'cluster',
+        return ('method', 'host', 'port', 'cluster',
                 'endpoint', 'schema', 'organization')
 
 


### PR DESCRIPTION
resolves #335

### Description

- Add `{{ target.method }}` to Jinja context
- This allows us to have clearer logs + easier debugging when running into errors like `The SQL contains 0 parameter markers, but x parameters were supplied` (e.g. #334)

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.