### PR TITLE
Add invocation env to user agent string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Fixes
 - `adapter.get_columns_in_relation` (method) and `get_columns_in_relation` (macro) now return identical responses. The previous behavior of `get_columns_in_relation` (macro) is now represented by a new macro, `get_columns_in_relation_raw` ([#354](https://github.com/dbt-labs/dbt-spark/issues/354), [#355](https://github.com/dbt-labs/dbt-spark/pull/355))
 
+### Under the hood
+- Add `DBT_INVOCATION_ENV` environment variable to ODBC user agent string
+
 ## dbt-spark 1.1.0 (April 28, 2022)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - `adapter.get_columns_in_relation` (method) and `get_columns_in_relation` (macro) now return identical responses. The previous behavior of `get_columns_in_relation` (macro) is now represented by a new macro, `get_columns_in_relation_raw` ([#354](https://github.com/dbt-labs/dbt-spark/issues/354), [#355](https://github.com/dbt-labs/dbt-spark/pull/355))
 
 ### Under the hood
-- Add `DBT_INVOCATION_ENV` environment variable to ODBC user agent string
+- Add `DBT_INVOCATION_ENV` environment variable to ODBC user agent string ([#366](https://github.com/dbt-labs/dbt-spark/pull/366))
 
 ## dbt-spark 1.1.0 (April 28, 2022)
 

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -1,3 +1,5 @@
+import os
+
 from contextlib import contextmanager
 
 import dbt.exceptions
@@ -7,6 +9,7 @@ from dbt.contracts.connection import ConnectionState, AdapterResponse
 from dbt.events import AdapterLogger
 from dbt.utils import DECIMALS
 from dbt.adapters.spark import __version__
+from dbt.tracking import DBT_INVOCATION_ENV
 
 try:
     from TCLIService.ttypes import TOperationState as ThriftState
@@ -409,9 +412,11 @@ class SparkConnectionManager(SQLConnectionManager):
                     cls.validate_creds(creds, required_fields)
 
                     dbt_spark_version = __version__.version
+                    dbt_invocation_env = os.getenv(DBT_INVOCATION_ENV) or "manual"
                     user_agent_entry = (
-                        f"dbt-labs-dbt-spark/{dbt_spark_version} (Databricks)"  # noqa
+                        f"dbt-labs-dbt-spark/{dbt_spark_version} (Databricks) {dbt_invocation_env}"  # noqa
                     )
+                    import ipdb; ipdb.set_trace()
 
                     # http://simba.wpengine.com/products/Spark/doc/ODBC_InstallGuide/unix/content/odbc/hi/configuring/serverside.htm
                     ssp = {f"SSP_{k}": f"{{{v}}}" for k, v in creds.server_side_parameters.items()}

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -413,7 +413,7 @@ class SparkConnectionManager(SQLConnectionManager):
 
                     dbt_spark_version = __version__.version
                     dbt_invocation_env = os.getenv(DBT_INVOCATION_ENV) or "manual"
-                    user_agent_entry = f"dbt-labs-dbt-spark/{dbt_spark_version} (Databricks) ({dbt_invocation_env})"  # noqa
+                    user_agent_entry = f"dbt-labs-dbt-spark/{dbt_spark_version} (Databricks, {dbt_invocation_env})"  # noqa
 
                     # http://simba.wpengine.com/products/Spark/doc/ODBC_InstallGuide/unix/content/odbc/hi/configuring/serverside.htm
                     ssp = {f"SSP_{k}": f"{{{v}}}" for k, v in creds.server_side_parameters.items()}

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -413,10 +413,7 @@ class SparkConnectionManager(SQLConnectionManager):
 
                     dbt_spark_version = __version__.version
                     dbt_invocation_env = os.getenv(DBT_INVOCATION_ENV) or "manual"
-                    user_agent_entry = (
-                        f"dbt-labs-dbt-spark/{dbt_spark_version} (Databricks) {dbt_invocation_env}"  # noqa
-                    )
-                    import ipdb; ipdb.set_trace()
+                    user_agent_entry = f"dbt-labs-dbt-spark/{dbt_spark_version} (Databricks) ({dbt_invocation_env})"  # noqa
 
                     # http://simba.wpengine.com/products/Spark/doc/ODBC_InstallGuide/unix/content/odbc/hi/configuring/serverside.htm
                     ssp = {f"SSP_{k}": f"{{{v}}}" for k, v in creds.server_side_parameters.items()}


### PR DESCRIPTION
Companion PR: https://github.com/databricks/dbt-databricks/pull/106

### Description

- Add the `DBT_INVOCATION_ENV` environment variable to the user agent, per Databricks' request (cc @ueshin @bilalaslamseattle)

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- ~This PR includes tests, or tests are not required/relevant for this PR~
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.
