### PR TITLE
Stringify relation in logging

### DIFF
--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -318,7 +318,7 @@ class SparkAdapter(SQLAdapter):
 
         columns: List[Dict[str, Any]] = []
         for relation in self.list_relations(database, schema):
-            logger.debug("Getting table schema for relation {}", relation)
+            logger.debug(f"Getting table schema for relation {relation}")
             columns.extend(self._get_columns_for_catalog(relation))
         return agate.Table.from_object(columns, column_types=DEFAULT_TYPE_TESTER)
 


### PR DESCRIPTION
resolves https://github.com/databricks/dbt-databricks/issues/115 (?)

Not totally sure what causes this one to arise, but I bet it's some weirdness around how the arguments are being passed through into `AdapterLogger`. (Throwback to https://github.com/dbt-labs/dbt-core/pull/4305.)

A simple resolution is to explicitly stringify the `relation`, or template out an f-string, rather than passing the full `Relation` object into `*args`.

```python
ipdb> logger.debug("Getting table schema for relation {}", relation)
*** TypeError: Object of type DatabricksRelation is not JSON serializable
```
```
ipdb> logger.debug("Getting table schema for relation {}", str(relation))
{"code": "E001", "data": {"args": ["dbt_jcohen.a_model"], "base_msg": "Getting table schema for relation {}", "name": "Spark"}, "invocation_id": "c6d345cc-dcbb-4790-8b2d-1b0e4b44e9ec", "level": "debug", "log_version": 2, "msg": "Spark adapter: Getting table schema for relation dbt_jcohen.a_model", "pid": 17840, "thread_name": "ThreadPoolExecutor-2_0", "ts": "2022-06-17T19:37:08.275536Z", "type": "log_line"}
```
```python
ipdb> logger.debug(f"Getting table schema for relation {relation}")
{"code": "E001", "data": {"args": [], "base_msg": "Getting table schema for relation dbt_jcohen.a_model", "name": "Spark"}, "invocation_id": "c6d345cc-dcbb-4790-8b2d-1b0e4b44e9ec", "level": "debug", "log_version": 2, "msg": "Spark adapter: Getting table schema for relation dbt_jcohen.a_model", "pid": 17840, "thread_name": "ThreadPoolExecutor-2_0", "ts": "2022-06-17T19:28:38.944487Z", "type": "log_line"}
```

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.
