### PR TITLE
Disable TestDateDiff on apache_spark

### DIFF
--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -48,6 +48,8 @@ class TestDateAdd(BaseDateAdd):
     pass
 
 
+# this generates too much SQL to run successfully in our testing environments :(
+@pytest.mark.skip_profile('apache_spark')
 @pytest.mark.skip_profile('spark_session')
 class TestDateDiff(BaseDateDiff):
     pass

--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -49,8 +49,7 @@ class TestDateAdd(BaseDateAdd):
 
 
 # this generates too much SQL to run successfully in our testing environments :(
-@pytest.mark.skip_profile('apache_spark')
-@pytest.mark.skip_profile('spark_session')
+@pytest.mark.skip_profile('apache_spark', 'spark_session')
 class TestDateDiff(BaseDateDiff):
     pass
 


### PR DESCRIPTION
Error from `TestDateDiff` on the `apache_spark` cluster:
```
ERROR    configured_file:functions.py:232 15:49:39.369957 [error] [MainThread]:     org.apache.hive.service.cli.HiveSQLException: Error running query: org.apache.spark.sql.AnalysisException: org.apache.hadoop.hive.ql.metadata.HiveException: MetaException(message:Insert of object "org.apache.hadoop.hive.metastore.model.MTable@445045d2" using statement "INSERT INTO TBLS (TBL_ID,CREATE_TIME,DB_ID,LAST_ACCESS_TIME,OWNER,RETENTION,IS_REWRITE_ENABLED,SD_ID,TBL_NAME,TBL_TYPE,VIEW_EXPANDED_TEXT,VIEW_ORIGINAL_TEXT) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)" failed : A truncation error was encountered trying to shrink LONG VARCHAR 'with data as (
ERROR    configured_std_out:functions.py:232 15:49:39      org.apache.hive.service.cli.HiveSQLException: Error running query: org.apache.spark.sql.AnalysisException: org.apache.hadoop.hive.ql.metadata.HiveException: MetaException(message:Insert of object "org.apache.hadoop.hive.metastore.model.MTable@445045d2" using statement "INSERT INTO TBLS (TBL_ID,CREATE_TIME,DB_ID,LAST_ACCESS_TIME,OWNER,RETENTION,IS_REWRITE_ENABLED,SD_ID,TBL_NAME,TBL_TYPE,VIEW_EXPANDED_TEXT,VIEW_ORIGINAL_TEXT) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)" failed : A truncation error was encountered trying to shrink LONG VARCHAR 'with data as (
```

Basically, `spark__datediff` produces a TON of SQL, and `TestDateDiff` calls `spark__datediff` several times — so, several tons of SQL. That's too much for our measly little dockerized Spark clusters. A TODO is to look into minifying the amount of SQL produced by `datediff`.