### PR TITLE
[CT-868] Pin pyodbc in dbt-spark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## dbt-spark 1.3.0b1 (Release TBD)
 
 ### Fixes
-- Pin `pyodbc` to version 4.0.32 to prevent overwriting `libodbc.so` and `libltdl.so` on Linux ([#397] (https://github.com/dbt-labs/dbt-spark/issues/397), [#398] (https://github.com/dbt-labs/dbt-spark/pull/398))
+- Pin `pyodbc` to version 4.0.32 to prevent overwriting `libodbc.so` and `libltdl.so` on Linux ([#397](https://github.com/dbt-labs/dbt-spark/issues/397), [#398](https://github.com/dbt-labs/dbt-spark/pull/398))
 
 ## dbt-spark 1.2.0rc1 (July 12, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## dbt-spark 1.3.0b1 (Release TBD)
 
 ### Fixes
-- Pin `pyodbc` to version 4.0.32 to prevent overwriting `libodbc.so` and `libltdl.so` on Linux ([#397](https://github.com/dbt-labs/dbt-spark/issues/397), [#398](https://github.com/dbt-labs/dbt-spark/pull/398))
+- Pin `pyodbc` to version 4.0.32 to prevent overwriting `libodbc.so` and `libltdl.so` on Linux ([#397](https://github.com/dbt-labs/dbt-spark/issues/397/), [#398](https://github.com/dbt-labs/dbt-spark/pull/398/))
+
+### Contributors
+- [@barberscott](https://github.com/barberscott)  ([#398](https://github.com/dbt-labs/dbt-spark/pull/398/))
 
 ## dbt-spark 1.2.0rc1 (July 12, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## dbt-spark 1.3.0b1 (Release TBD)
 
+### Fixes
+- Pin `pyodbc` to version 4.0.32 to prevent overwriting `libodbc.so` and `libltdl.so` on Linux ([#397] (https://github.com/dbt-labs/dbt-spark/issues/397), [#398] (https://github.com/dbt-labs/dbt-spark/pull/398))
 
 ## dbt-spark 1.2.0rc1 (July 12, 2022)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyHive[hive]>=0.6.0,<0.7.0
-pyodbc>=4.0.30
+pyodbc==4.0.32
 sqlparams>=3.0.0
 thrift>=0.13.0
 sqlparse>=0.4.2 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Pin pyodbc to a known-working version until pyodbc>=4.0.35 releases.

resolves #397 

### Description

Pin the pyodbc version to prevent a bad installation of libodbc.so and libltdl.s on linux distros.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.
