### PR TITLE
make dev installs requirements.txt too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: dev
 dev: ## Installs adapter in develop mode along with development depedencies
 	@\
-	pip install -r dev-requirements.txt && pre-commit install
+	pip install -r requirements.txt -r dev-requirements.txt && pre-commit install
 
 .PHONY: mypy
 mypy: ## Runs mypy against staged changes for static type checking.


### PR DESCRIPTION
`make dev` doesn't install everything you need to run tests today. this aims to fix that.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.
