### PR TITLE
modify make and tox for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ linecheck: ## Checks for all Python lines 100 characters or more
 .PHONY: unit
 unit: ## Runs unit tests with py38.
 	@\
-	tox -e py38
+	tox unit
 
 .PHONY: test
 test: ## Runs unit tests with py38 and code checks against staged changes.

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = unit, flake8, integration-spark-thrift
 
 [testenv:unit]
 basepython = python3.8
-commands = /bin/bash -c '{envpython} -m pytest -v {posargs} tests/unit'
+commands = /bin/bash -c '{envpython} -m unittest tests/unit/*.py'
 passenv = DBT_* PYTEST_ADDOPTS
 deps =
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
`make unit` wasn't running unit tests. Now it should.

Reviewers: please run `make dev` then `make unit` in a new virtual environment and report back if this works for you or not.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.
