### PR TITLE
enable python model test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ def databricks_cluster_target():
         "connect_retries": 3,
         "connect_timeout": 5,
         "retry_all": True,
+        "user": os.getenv('DBT_DATABRICKS_USER'),
     }
 
 
@@ -91,7 +92,7 @@ def databricks_http_cluster_target():
         "connect_retries": 5,
         "connect_timeout": 60, 
         "retry_all": bool(os.getenv('DBT_DATABRICKS_RETRY_ALL', False)),
-        "user": os.getenv('DBT_DATABRICKS_USER')
+        "user": os.getenv('DBT_DATABRICKS_USER'),
     }
 
 

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -3,7 +3,7 @@ import pytest
 from dbt.tests.util import run_dbt, write_file, run_dbt_and_capture
 from dbt.tests.adapter.python_model.test_python_model import BasePythonModelTests
 
-@pytest.skip("Need to supply extra config", allow_module_level=True)
+@pytest.mark.skip_profile("apache_spark", "spark_session", "databricks_sql_endpoint")
 class TestPythonModelSpark(BasePythonModelTests):
     pass
 
@@ -30,8 +30,6 @@ def model(dbt, spark):
 """
 
 
-
-@pytest.skip("Need to supply extra config", allow_module_level=True)
 @pytest.mark.skip_profile("apache_spark", "spark_session", "databricks_sql_endpoint")
 class TestChangingSchemaSpark:
     @pytest.fixture(scope="class")


### PR DESCRIPTION
This PR will enable running python model tests for `databricks_cluster` and `databricks_http_cluster` connection methods in Circle CI, we added new env var `DBT_DATABRICKS_USER` to support it