### PR TITLE
Set default file format to parquet

### DIFF
--- a/.changes/unreleased/Features-20220811-125801.yaml
+++ b/.changes/unreleased/Features-20220811-125801.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: 'If file_format is not specified, use default: ''delta'' on ODBC connections,
+  ''parquet'' otherwise'
+time: 2022-08-11T12:58:01.752129+02:00
+custom:
+  Author: jtcohen6
+  Issue: "363"
+  PR: "422"

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -143,7 +143,7 @@ class SparkCredentials(Credentials):
         return self.host
 
     def _connection_keys(self):
-        return ("host", "port", "cluster", "endpoint", "schema", "organization")
+        return ("host", "port", "cluster", "endpoint", "schema", "organization", "method")
 
 
 class PyhiveConnectionWrapper(object):

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -3,7 +3,8 @@
 {%- endmacro -%}
 
 {% macro spark__file_format_clause() %}
-  {%- set file_format = config.get('file_format', validator=validation.any[basestring]) or 'parquet' -%}
+  {%- set default_format = 'delta' if target.method == 'ODBC' else 'parquet' -%}
+  {%- set file_format = config.get('file_format', default_format) -%}
   {%- if file_format is not none %}
     using {{ file_format }}
   {%- endif %}

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -3,7 +3,7 @@
 {%- endmacro -%}
 
 {% macro spark__file_format_clause() %}
-  {%- set file_format = config.get('file_format', validator=validation.any[basestring]) -%}
+  {%- set file_format = config.get('file_format', default='parquet', validator=validation.any[basestring]) -%}
   {%- if file_format is not none %}
     using {{ file_format }}
   {%- endif %}

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -3,7 +3,7 @@
 {%- endmacro -%}
 
 {% macro spark__file_format_clause() %}
-  {%- set file_format = config.get('file_format', default='parquet', validator=validation.any[basestring]) -%}
+  {%- set file_format = config.get('file_format', validator=validation.any[basestring]) or 'parquet' -%}
   {%- if file_format is not none %}
     using {{ file_format }}
   {%- endif %}

--- a/tests/functional/adapter/test_incremental_unique_id.py
+++ b/tests/functional/adapter/test_incremental_unique_id.py
@@ -6,6 +6,9 @@ class TestUniqueKeySpark(BaseIncrementalUniqueKey):
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
+            "seeds": {
+                "+file_format": "delta",
+            },
             "models": {
                 "+file_format": "delta",
                 "+incremental_strategy": "merge",

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -41,7 +41,7 @@ class TestSparkMacros(unittest.TestCase):
         template = self.__get_template('adapters.sql')
         sql = self.__run_macro(template, 'spark__create_table_as', False, 'my_table', 'select 1').strip()
 
-        self.assertEqual(sql, "create table my_table as select 1")
+        self.assertEqual(sql, "create table my_table using parquet as select 1")
 
     def test_macros_create_table_as_file_format(self):
         template = self.__get_template('adapters.sql')
@@ -91,7 +91,7 @@ class TestSparkMacros(unittest.TestCase):
 
         self.config['partition_by'] = 'partition_1'
         sql = self.__run_macro(template, 'spark__create_table_as', False, 'my_table', 'select 1').strip()
-        self.assertEqual(sql, "create table my_table partitioned by (partition_1) as select 1")
+        self.assertEqual(sql, "create table my_table using parquet partitioned by (partition_1) as select 1")
 
     def test_macros_create_table_as_partitions(self):
         template = self.__get_template('adapters.sql')
@@ -99,7 +99,7 @@ class TestSparkMacros(unittest.TestCase):
         self.config['partition_by'] = ['partition_1', 'partition_2']
         sql = self.__run_macro(template, 'spark__create_table_as', False, 'my_table', 'select 1').strip()
         self.assertEqual(sql,
-                         "create table my_table partitioned by (partition_1,partition_2) as select 1")
+                         "create table my_table using parquet partitioned by (partition_1,partition_2) as select 1")
 
     def test_macros_create_table_as_cluster(self):
         template = self.__get_template('adapters.sql')
@@ -107,7 +107,7 @@ class TestSparkMacros(unittest.TestCase):
         self.config['clustered_by'] = 'cluster_1'
         self.config['buckets'] = '1'
         sql = self.__run_macro(template, 'spark__create_table_as', False, 'my_table', 'select 1').strip()
-        self.assertEqual(sql, "create table my_table clustered by (cluster_1) into 1 buckets as select 1")
+        self.assertEqual(sql, "create table my_table using parquet clustered by (cluster_1) into 1 buckets as select 1")
 
     def test_macros_create_table_as_clusters(self):
         template = self.__get_template('adapters.sql')
@@ -115,14 +115,14 @@ class TestSparkMacros(unittest.TestCase):
         self.config['clustered_by'] = ['cluster_1', 'cluster_2']
         self.config['buckets'] = '1'
         sql = self.__run_macro(template, 'spark__create_table_as', False, 'my_table', 'select 1').strip()
-        self.assertEqual(sql, "create table my_table clustered by (cluster_1,cluster_2) into 1 buckets as select 1")
+        self.assertEqual(sql, "create table my_table using parquet clustered by (cluster_1,cluster_2) into 1 buckets as select 1")
 
     def test_macros_create_table_as_location(self):
         template = self.__get_template('adapters.sql')
 
         self.config['location_root'] = '/mnt/root'
         sql = self.__run_macro(template, 'spark__create_table_as', False, 'my_table', 'select 1').strip()
-        self.assertEqual(sql, "create table my_table location '/mnt/root/my_table' as select 1")
+        self.assertEqual(sql, "create table my_table using parquet location '/mnt/root/my_table' as select 1")
 
     def test_macros_create_table_as_comment(self):
         template = self.__get_template('adapters.sql')
@@ -130,7 +130,7 @@ class TestSparkMacros(unittest.TestCase):
         self.config['persist_docs'] = {'relation': True}
         self.default_context['model'].description = 'Description Test'
         sql = self.__run_macro(template, 'spark__create_table_as', False, 'my_table', 'select 1').strip()
-        self.assertEqual(sql, "create table my_table comment 'Description Test' as select 1")
+        self.assertEqual(sql, "create table my_table using parquet comment 'Description Test' as select 1")
 
     def test_macros_create_table_as_all(self):
         template = self.__get_template('adapters.sql')

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -16,6 +16,7 @@ class TestSparkMacros(unittest.TestCase):
             'model': mock.Mock(),
             'exceptions': mock.Mock(),
             'config': mock.Mock(),
+            'target': mock.Mock(),
             'adapter': mock.Mock(),
             'return': lambda r: r,
         }


### PR DESCRIPTION
resolves #363

### Description

We already set this default here, but it's clearly not flowing through properly, because `AdapterConfig` doesn't really seem to be working in `dbt-core` (https://github.com/dbt-labs/dbt-core/issues/5236):
https://github.com/dbt-labs/dbt-spark/blob/8744cf1faa0b57fe9e797a32a109ba4e7a056e76/dbt/adapters/spark/impl.py#L38

Let's set the default explicitly in the macro, so that if the user hasn't provided a `file_format`, `dbt-spark` uses Parquet. This prevents _weird_ issues with query rewrite in Databricks SQL warehouses, too (https://github.com/dbt-labs/dbt-spark/issues/236).

**Update:** If the user is connecting via `ODBC` (= Databricks), let's use `delta` as the default file format instead. This helps out Databricks SQL warehouse connections, which can _only_ write Delta-formatted tables.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.
