### PR TITLE
Dramatically faster caching

### DIFF
--- a/.changes/unreleased/Features-20220819-215714.yaml
+++ b/.changes/unreleased/Features-20220819-215714.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Faster caching at run start. **Note:** Requires Spark v3
+time: 2022-08-19T21:57:14.56716+02:00
+custom:
+  Author: TalkWIthKeyboard
+  Issue: "228"
+  PR: "342"

--- a/dbt/adapters/spark/column.py
+++ b/dbt/adapters/spark/column.py
@@ -2,14 +2,14 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, TypeVar, Union
 
 from dbt.adapters.base.column import Column
-from dbt.dataclass_schema import dbtClassMixin
+from dbt.contracts.relation import FakeAPIObject
 from hologram import JsonDict
 
 Self = TypeVar("Self", bound="SparkColumn")
 
 
 @dataclass
-class SparkColumn(dbtClassMixin, Column):
+class SparkColumn(FakeAPIObject, Column):
     table_database: Optional[str] = None
     table_schema: Optional[str] = None
     table_name: Optional[str] = None

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -170,8 +170,7 @@ class SparkAdapter(SQLAdapter):
             dbt.exceptions.raise_compiler_error(
                 "Attempted to cache a null schema for {}".format(name)
             )
-        if dbt.flags.USE_CACHE:
-            self.cache.add_schema(None, schema)
+        self.cache.add_schema(None, schema)
         # so jinja doesn't render things
         return ""
 

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -221,7 +221,7 @@ class SparkAdapter(SQLAdapter):
 
     def parse_describe_extended(
         self, relation: Relation, raw_rows: List[agate.Row]
-    ) -> Tuple[Dict[str, any], List[SparkColumn]]:
+    ) -> Tuple[Dict[str, Any], List[SparkColumn]]:
         # Convert the Row to a dict
         dict_rows = [dict(zip(row._keys, row._values)) for row in raw_rows]
         # Find the separator between the rows and the metadata provided
@@ -283,7 +283,7 @@ class SparkAdapter(SQLAdapter):
 
     def _get_updated_relation(self, relation: BaseRelation) -> Optional[SparkRelation]:
         metadata = None
-        columns = []
+        columns: List[SparkColumn] = []
 
         try:
             rows: List[agate.Row] = self.execute_macro(

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -29,7 +29,8 @@ logger = AdapterLogger("Spark")
 
 GET_COLUMNS_IN_RELATION_RAW_MACRO_NAME = "get_columns_in_relation_raw"
 LIST_SCHEMAS_MACRO_NAME = "list_schemas"
-LIST_RELATIONS_MACRO_NAME = "list_relations_without_caching"
+LIST_TABLES_MACRO_NAME = "spark__list_tables_without_caching"
+LIST_VIEWS_MACRO_NAME = "spark__list_views_without_caching"
 DROP_RELATION_MACRO_NAME = "drop_relation"
 FETCH_TBL_PROPERTIES_MACRO_NAME = "fetch_tbl_properties"
 
@@ -128,9 +129,16 @@ class SparkAdapter(SQLAdapter):
     def list_relations_without_caching(
         self, schema_relation: SparkRelation
     ) -> List[SparkRelation]:
-        kwargs = {"schema_relation": schema_relation}
+        kwargs = {'relation': schema_relation}
         try:
-            results = self.execute_macro(LIST_RELATIONS_MACRO_NAME, kwargs=kwargs)
+            tables = self.execute_macro(
+                LIST_TABLES_MACRO_NAME,
+                kwargs=kwargs
+            )
+            views = self.execute_macro(
+                LIST_VIEWS_MACRO_NAME,
+                kwargs=kwargs
+            )
         except dbt.exceptions.RuntimeException as e:
             errmsg = getattr(e, "msg", "")
             if f"Database '{schema_relation}' not found" in errmsg:
@@ -139,27 +147,39 @@ class SparkAdapter(SQLAdapter):
                 description = "Error while retrieving information about"
                 logger.debug(f"{description} {schema_relation}: {e.msg}")
                 return []
-
+                
+        
         relations = []
-        for row in results:
-            if len(row) != 4:
-                raise dbt.exceptions.RuntimeException(
-                    f'Invalid value from "show table extended ...", '
-                    f"got {len(row)} values, expected 4"
-                )
-            _schema, name, _, information = row
-            rel_type = RelationType.View if "Type: VIEW" in information else RelationType.Table
-            is_delta = "Provider: delta" in information
-            is_hudi = "Provider: hudi" in information
+        for tbl in tables:
+            rel_type = ('view' if tbl['tableName'] in views.columns["viewName"].values() else 'table')
             relation = self.Relation.create(
-                schema=_schema,
-                identifier=name,
+                schema=tbl['database'],
+                identifier=tbl['tableName'],
                 type=rel_type,
-                information=information,
-                is_delta=is_delta,
-                is_hudi=is_hudi,
             )
             relations.append(relation)
+
+#        relations = []
+#        for row in results:
+#            if len(row) != 4:
+#                raise dbt.exceptions.RuntimeException(
+#                    f'Invalid value from "show table extended ...", '
+#                    f'got {len(row)} values, expected 4'
+#                )
+#            _schema, name, _, information = row
+#            rel_type = RelationType.View \
+#                if 'Type: VIEW' in information else RelationType.Table
+#            is_delta = 'Provider: delta' in information
+#            is_hudi = 'Provider: hudi' in information
+#            relation = self.Relation.create(
+#                schema=_schema,
+#                identifier=name,
+#                type=rel_type,
+#                information=information,
+#                is_delta=is_delta,
+#                is_hudi=is_hudi,
+#            )
+#            relations.append(relation)
 
         return relations
 

--- a/dbt/adapters/spark/relation.py
+++ b/dbt/adapters/spark/relation.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Hashable
+from typing import Optional, List
 
 from dataclasses import dataclass, field
 
@@ -46,6 +46,4 @@ class SparkRelation(BaseRelation):
         return super().render()
 
     def has_information(self) -> bool:
-        return self.owner is not None and \
-               self.stats is not None and \
-               len(self.columns) > 0
+        return self.owner is not None and self.stats is not None and len(self.columns) > 0

--- a/dbt/adapters/spark/relation.py
+++ b/dbt/adapters/spark/relation.py
@@ -1,9 +1,11 @@
-from typing import Optional
+from typing import Optional, List, Dict, Hashable
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from dbt.adapters.base.relation import BaseRelation, Policy
 from dbt.exceptions import RuntimeException
+
+from dbt.adapters.spark.column import SparkColumn
 
 
 @dataclass
@@ -27,7 +29,9 @@ class SparkRelation(BaseRelation):
     quote_character: str = "`"
     is_delta: Optional[bool] = None
     is_hudi: Optional[bool] = None
-    information: Optional[str] = None
+    owner: Optional[str] = None
+    stats: Optional[str] = None
+    columns: List[SparkColumn] = field(default_factory=lambda: [])
 
     def __post_init__(self):
         if self.database != self.schema and self.database:
@@ -40,3 +44,8 @@ class SparkRelation(BaseRelation):
                 "include, but only one can be set"
             )
         return super().render()
+
+    def has_information(self) -> bool:
+        return self.owner is not None and \
+               self.stats is not None and \
+               len(self.columns) > 0

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -194,12 +194,20 @@
   {{ return(adapter.get_columns_in_relation(relation)) }}
 {% endmacro %}
 
-{% macro spark__list_relations_without_caching(relation) %}
-  {% call statement('list_relations_without_caching', fetch_result=True) -%}
-    show table extended in {{ relation }} like '*'
+{% macro spark__list_tables_without_caching(relation) %}
+  {% call statement('list_tables_without_caching', fetch_result=True) -%}
+    show tables in {{ relation.schema }} like '*'
   {% endcall %}
 
-  {% do return(load_result('list_relations_without_caching').table) %}
+  {% do return(load_result('list_tables_without_caching').table) %}
+{% endmacro %}
+
+{% macro spark__list_views_without_caching(relation) %}
+  {% call statement('list_views_without_caching', fetch_result=True) -%}
+    show views in {{ relation.schema }} like '*'
+  {% endcall %}
+
+  {% do return(load_result('list_views_without_caching').table) %}
 {% endmacro %}
 
 {% macro spark__list_schemas(database) -%}

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -206,7 +206,7 @@
 {% endmacro %}
 
 {% macro list_views_without_caching(relation) %}
-  {{ return(adapter.dispatch('list_tables_without_caching', 'dbt')(relation)) }}
+  {{ return(adapter.dispatch('list_views_without_caching', 'dbt')(relation)) }}
 {%- endmacro -%}
 
 {% macro spark__list_views_without_caching(relation) %}

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -194,19 +194,25 @@
   {{ return(adapter.get_columns_in_relation(relation)) }}
 {% endmacro %}
 
+{% macro list_tables_without_caching(relation) %}
+  {{ return(adapter.dispatch('list_tables_without_caching', 'dbt')(relation)) }}
+{%- endmacro -%}
+
 {% macro spark__list_tables_without_caching(relation) %}
   {% call statement('list_tables_without_caching', fetch_result=True) -%}
-    show tables in {{ relation.schema }} like '*'
+    show tables in {{ relation.schema }}
   {% endcall %}
-
   {% do return(load_result('list_tables_without_caching').table) %}
 {% endmacro %}
 
+{% macro list_views_without_caching(relation) %}
+  {{ return(adapter.dispatch('list_tables_without_caching', 'dbt')(relation)) }}
+{%- endmacro -%}
+
 {% macro spark__list_views_without_caching(relation) %}
   {% call statement('list_views_without_caching', fetch_result=True) -%}
-    show views in {{ relation.schema }} like '*'
+    show views in {{ relation.schema }}
   {% endcall %}
-
   {% do return(load_result('list_views_without_caching').table) %}
 {% endmacro %}
 

--- a/dbt/include/spark/macros/materializations/table.sql
+++ b/dbt/include/spark/macros/materializations/table.sql
@@ -3,7 +3,7 @@
   {%- set identifier = model['alias'] -%}
   {%- set grant_config = config.get('grants') -%}
 
-  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier, needs_information=True) -%}
   {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
                                                 database=database,

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -23,9 +23,6 @@ class TestSingularTestsSpark(BaseSingularTests):
     pass
 
 
-# The local cluster currently tests on spark 2.x, which does not support this
-# if we upgrade it to 3.x, we can enable this test
-@pytest.mark.skip_profile('apache_spark')
 class TestSingularTestsEphemeralSpark(BaseSingularTestsEphemeral):
     pass
 
@@ -48,8 +45,7 @@ class TestGenericTestsSpark(BaseGenericTests):
     pass
 
 
-# These tests were not enabled in the dbtspec files, so skipping here.
-# Error encountered was: Error running query: java.lang.ClassNotFoundException: delta.DefaultSource
+# Snapshots require Delta
 @pytest.mark.skip_profile('apache_spark', 'spark_session')
 class TestSnapshotCheckColsSpark(BaseSnapshotCheckCols):
     @pytest.fixture(scope="class")
@@ -64,8 +60,7 @@ class TestSnapshotCheckColsSpark(BaseSnapshotCheckCols):
         }
 
 
-# These tests were not enabled in the dbtspec files, so skipping here.
-# Error encountered was: Error running query: java.lang.ClassNotFoundException: delta.DefaultSource
+# Snapshots require Delta
 @pytest.mark.skip_profile('apache_spark', 'spark_session')
 class TestSnapshotTimestampSpark(BaseSnapshotTimestamp):
     @pytest.fixture(scope="class")

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 
 import dbt.flags as flags
+import pytest
 from dbt.exceptions import RuntimeException
 from agate import Row
 from pyhive import hive
@@ -298,8 +299,27 @@ class TestSparkAdapter(unittest.TestCase):
                       for r in plain_rows]
 
         config = self._get_target_http(self.project_cfg)
-        rows = SparkAdapter(config).parse_describe_extended(
+        metadata, rows = SparkAdapter(config).parse_describe_extended(
             relation, input_cols)
+
+        self.assertDictEqual(metadata, {
+            '# col_name': 'data_type',
+            'dt': 'date',
+            None: None,
+            '# Detailed Table Information': None,
+            'Database': None,
+            'Owner': 'root',
+            'Created Time': 'Wed Feb 04 18:15:00 UTC 1815',
+            'Last Access': 'Wed May 20 19:25:00 UTC 1925',
+            'Type': 'MANAGED',
+            'Provider': 'delta',
+            'Location': '/mnt/vo',
+            'Serde Library': 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',
+            'InputFormat': 'org.apache.hadoop.mapred.SequenceFileInputFormat',
+            'OutputFormat': 'org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat',
+            'Partition Provider': 'Catalog'
+        })
+
         self.assertEqual(len(rows), 4)
         self.assertEqual(rows[0].to_column_dict(omit_none=False), {
             'table_database': None,
@@ -379,7 +399,7 @@ class TestSparkAdapter(unittest.TestCase):
                       for r in plain_rows]
 
         config = self._get_target_http(self.project_cfg)
-        rows = SparkAdapter(config).parse_describe_extended(
+        _, rows = SparkAdapter(config).parse_describe_extended(
             relation, input_cols)
 
         self.assertEqual(rows[0].to_column_dict().get('table_owner'), '1234')
@@ -419,8 +439,26 @@ class TestSparkAdapter(unittest.TestCase):
                       for r in plain_rows]
 
         config = self._get_target_http(self.project_cfg)
-        rows = SparkAdapter(config).parse_describe_extended(
+        metadata, rows = SparkAdapter(config).parse_describe_extended(
             relation, input_cols)
+
+        self.assertEqual(metadata, {
+            None: None,
+            '# Detailed Table Information': None,
+            'Database': None,
+            'Owner': 'root',
+            'Created Time': 'Wed Feb 04 18:15:00 UTC 1815',
+            'Last Access': 'Wed May 20 19:25:00 UTC 1925',
+            'Statistics': '1109049927 bytes, 14093476 rows',
+            'Type': 'MANAGED',
+            'Provider': 'delta',
+            'Location': '/mnt/vo',
+            'Serde Library': 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',
+            'InputFormat': 'org.apache.hadoop.mapred.SequenceFileInputFormat',
+            'OutputFormat': 'org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat',
+            'Partition Provider': 'Catalog'
+        })
+
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0].to_column_dict(omit_none=False), {
             'table_database': None,
@@ -496,240 +534,3 @@ class TestSparkAdapter(unittest.TestCase):
         }
         with self.assertRaises(RuntimeException):
             config_from_parts_or_dicts(self.project_cfg, profile)
-
-    def test_parse_columns_from_information_with_table_type_and_delta_provider(self):
-        self.maxDiff = None
-        rel_type = SparkRelation.get_relation_type.Table
-
-        # Mimics the output of Spark in the information column
-        information = (
-            "Database: default_schema\n"
-            "Table: mytable\n"
-            "Owner: root\n"
-            "Created Time: Wed Feb 04 18:15:00 UTC 1815\n"
-            "Last Access: Wed May 20 19:25:00 UTC 1925\n"
-            "Created By: Spark 3.0.1\n"
-            "Type: MANAGED\n"
-            "Provider: delta\n"
-            "Statistics: 123456789 bytes\n"
-            "Location: /mnt/vo\n"
-            "Serde Library: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe\n"
-            "InputFormat: org.apache.hadoop.mapred.SequenceFileInputFormat\n"
-            "OutputFormat: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat\n"
-            "Partition Provider: Catalog\n"
-            "Partition Columns: [`dt`]\n"
-            "Schema: root\n"
-            " |-- col1: decimal(22,0) (nullable = true)\n"
-            " |-- col2: string (nullable = true)\n"
-            " |-- dt: date (nullable = true)\n"
-            " |-- struct_col: struct (nullable = true)\n"
-            " |    |-- struct_inner_col: string (nullable = true)\n"
-        )
-        relation = SparkRelation.create(
-            schema='default_schema',
-            identifier='mytable',
-            type=rel_type,
-            information=information
-        )
-
-        config = self._get_target_http(self.project_cfg)
-        columns = SparkAdapter(config).parse_columns_from_information(
-            relation)
-        self.assertEqual(len(columns), 4)
-        self.assertEqual(columns[0].to_column_dict(omit_none=False), {
-            'table_database': None,
-            'table_schema': relation.schema,
-            'table_name': relation.name,
-            'table_type': rel_type,
-            'table_owner': 'root',
-            'column': 'col1',
-            'column_index': 0,
-            'dtype': 'decimal(22,0)',
-            'numeric_scale': None,
-            'numeric_precision': None,
-            'char_size': None,
-
-            'stats:bytes:description': '',
-            'stats:bytes:include': True,
-            'stats:bytes:label': 'bytes',
-            'stats:bytes:value': 123456789,
-        })
-
-        self.assertEqual(columns[3].to_column_dict(omit_none=False), {
-            'table_database': None,
-            'table_schema': relation.schema,
-            'table_name': relation.name,
-            'table_type': rel_type,
-            'table_owner': 'root',
-            'column': 'struct_col',
-            'column_index': 3,
-            'dtype': 'struct',
-            'numeric_scale': None,
-            'numeric_precision': None,
-            'char_size': None,
-
-            'stats:bytes:description': '',
-            'stats:bytes:include': True,
-            'stats:bytes:label': 'bytes',
-            'stats:bytes:value': 123456789,
-        })
-
-    def test_parse_columns_from_information_with_view_type(self):
-        self.maxDiff = None
-        rel_type = SparkRelation.get_relation_type.View
-        information = (
-            "Database: default_schema\n"
-            "Table: myview\n"
-            "Owner: root\n"
-            "Created Time: Wed Feb 04 18:15:00 UTC 1815\n"
-            "Last Access: UNKNOWN\n"
-            "Created By: Spark 3.0.1\n"
-            "Type: VIEW\n"
-            "View Text: WITH base (\n"
-            "    SELECT * FROM source_table\n"
-            ")\n"
-            "SELECT col1, col2, dt FROM base\n"
-            "View Original Text: WITH base (\n"
-            "    SELECT * FROM source_table\n"
-            ")\n"
-            "SELECT col1, col2, dt FROM base\n"
-            "View Catalog and Namespace: spark_catalog.default\n"
-            "View Query Output Columns: [col1, col2, dt]\n"
-            "Table Properties: [view.query.out.col.1=col1, view.query.out.col.2=col2, "
-            "transient_lastDdlTime=1618324324, view.query.out.col.3=dt, "
-            "view.catalogAndNamespace.part.0=spark_catalog, "
-            "view.catalogAndNamespace.part.1=default]\n"
-            "Serde Library: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe\n"
-            "InputFormat: org.apache.hadoop.mapred.SequenceFileInputFormat\n"
-            "OutputFormat: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat\n"
-            "Storage Properties: [serialization.format=1]\n"
-            "Schema: root\n"
-            " |-- col1: decimal(22,0) (nullable = true)\n"
-            " |-- col2: string (nullable = true)\n"
-            " |-- dt: date (nullable = true)\n"
-            " |-- struct_col: struct (nullable = true)\n"
-            " |    |-- struct_inner_col: string (nullable = true)\n"
-        )
-        relation = SparkRelation.create(
-            schema='default_schema',
-            identifier='myview',
-            type=rel_type,
-            information=information
-        )
-
-        config = self._get_target_http(self.project_cfg)
-        columns = SparkAdapter(config).parse_columns_from_information(
-            relation)
-        self.assertEqual(len(columns), 4)
-        self.assertEqual(columns[1].to_column_dict(omit_none=False), {
-            'table_database': None,
-            'table_schema': relation.schema,
-            'table_name': relation.name,
-            'table_type': rel_type,
-            'table_owner': 'root',
-            'column': 'col2',
-            'column_index': 1,
-            'dtype': 'string',
-            'numeric_scale': None,
-            'numeric_precision': None,
-            'char_size': None
-        })
-
-        self.assertEqual(columns[3].to_column_dict(omit_none=False), {
-            'table_database': None,
-            'table_schema': relation.schema,
-            'table_name': relation.name,
-            'table_type': rel_type,
-            'table_owner': 'root',
-            'column': 'struct_col',
-            'column_index': 3,
-            'dtype': 'struct',
-            'numeric_scale': None,
-            'numeric_precision': None,
-            'char_size': None
-        })
-
-    def test_parse_columns_from_information_with_table_type_and_parquet_provider(self):
-        self.maxDiff = None
-        rel_type = SparkRelation.get_relation_type.Table
-
-        information = (
-            "Database: default_schema\n"
-            "Table: mytable\n"
-            "Owner: root\n"
-            "Created Time: Wed Feb 04 18:15:00 UTC 1815\n"
-            "Last Access: Wed May 20 19:25:00 UTC 1925\n"
-            "Created By: Spark 3.0.1\n"
-            "Type: MANAGED\n"
-            "Provider: parquet\n"
-            "Statistics: 1234567890 bytes, 12345678 rows\n"
-            "Location: /mnt/vo\n"
-            "Serde Library: org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe\n"
-            "InputFormat: org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat\n"
-            "OutputFormat: org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat\n"
-            "Schema: root\n"
-            " |-- col1: decimal(22,0) (nullable = true)\n"
-            " |-- col2: string (nullable = true)\n"
-            " |-- dt: date (nullable = true)\n"
-            " |-- struct_col: struct (nullable = true)\n"
-            " |    |-- struct_inner_col: string (nullable = true)\n"
-        )
-        relation = SparkRelation.create(
-            schema='default_schema',
-            identifier='mytable',
-            type=rel_type,
-            information=information
-        )
-
-        config = self._get_target_http(self.project_cfg)
-        columns = SparkAdapter(config).parse_columns_from_information(
-            relation)
-        self.assertEqual(len(columns), 4)
-        self.assertEqual(columns[2].to_column_dict(omit_none=False), {
-            'table_database': None,
-            'table_schema': relation.schema,
-            'table_name': relation.name,
-            'table_type': rel_type,
-            'table_owner': 'root',
-            'column': 'dt',
-            'column_index': 2,
-            'dtype': 'date',
-            'numeric_scale': None,
-            'numeric_precision': None,
-            'char_size': None,
-
-            'stats:bytes:description': '',
-            'stats:bytes:include': True,
-            'stats:bytes:label': 'bytes',
-            'stats:bytes:value': 1234567890,
-
-            'stats:rows:description': '',
-            'stats:rows:include': True,
-            'stats:rows:label': 'rows',
-            'stats:rows:value': 12345678
-        })
-
-        self.assertEqual(columns[3].to_column_dict(omit_none=False), {
-            'table_database': None,
-            'table_schema': relation.schema,
-            'table_name': relation.name,
-            'table_type': rel_type,
-            'table_owner': 'root',
-            'column': 'struct_col',
-            'column_index': 3,
-            'dtype': 'struct',
-            'numeric_scale': None,
-            'numeric_precision': None,
-            'char_size': None,
-
-            'stats:bytes:description': '',
-            'stats:bytes:include': True,
-            'stats:bytes:label': 'bytes',
-            'stats:bytes:value': 1234567890,
-
-            'stats:rows:description': '',
-            'stats:rows:include': True,
-            'stats:rows:label': 'rows',
-            'stats:rows:value': 12345678
-        })
-


### PR DESCRIPTION
Rebase of #342

### Description

- Resolves https://github.com/dbt-labs/dbt-spark/issues/228 by using `show tables` + `show views` instead of `show table extended ... like '*'` (very slow)
- Resolve #431 by always invalidating cache during `get_columns_in_relation` to avoid inconsistencies.

_Eventually_, we may want to investigate the feasibility of column-level cache (in)validation. For now, let's just stick to the core behavior. Columns will still be cached, but `get_columns_in_relation` will skip over the cached values and run a `describe` query instead.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
