### PR TITLE
More flexible cluster configuration

### DIFF
--- a/.changes/unreleased/Features-20220923-101248.yaml
+++ b/.changes/unreleased/Features-20220923-101248.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Support job cluster in notebook submission method, remove requirement for user
+  for python model submission
+time: 2022-09-23T10:12:48.288911-07:00
+custom:
+  Author: ChenyuLInx
+  Issue: "444"
+  PR: "467"

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -82,6 +82,10 @@ class SparkCredentials(Credentials):
             data["database"] = None
         return data
 
+    @property
+    def cluster_id(self):
+        return self.cluster
+
     def __post_init__(self):
         # spark classifies database and schema as the same thing
         if self.database is not None and self.database != self.schema:

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -18,8 +18,8 @@ from dbt.adapters.spark import SparkConnectionManager
 from dbt.adapters.spark import SparkRelation
 from dbt.adapters.spark import SparkColumn
 from dbt.adapters.spark.python_submissions import (
-    DBNotebookPythonJobHelper,
-    DBCommandsApiPythonJobHelper,
+    JobClusterPythonJobHelper,
+    AllPurposeClusterPythonJobHelper,
 )
 from dbt.adapters.base import BaseRelation
 from dbt.clients.agate_helper import DEFAULT_TYPE_TESTER
@@ -377,13 +377,13 @@ class SparkAdapter(SQLAdapter):
 
     @property
     def default_python_submission_method(self) -> str:
-        return "commands"
+        return "all_purpose_cluster"
 
     @property
     def python_submission_helpers(self) -> Dict[str, Type[PythonJobHelper]]:
         return {
-            "notebook": DBNotebookPythonJobHelper,
-            "commands": DBCommandsApiPythonJobHelper,
+            "job_cluster": JobClusterPythonJobHelper,
+            "all_purpose_cluster": AllPurposeClusterPythonJobHelper,
         }
 
     def standardize_grants_dict(self, grants_table: agate.Table) -> dict:

--- a/dbt/adapters/spark/python_submissions.py
+++ b/dbt/adapters/spark/python_submissions.py
@@ -116,7 +116,14 @@ class DBNotebookPythonJobHelper(BaseDatabricksHelper):
             headers=self.auth_header,
             json={
                 "run_name": f"{self.schema}-{self.identifier}-{uuid.uuid4()}",
-                "existing_cluster_id": self.credentials.cluster,
+                # "existing_cluster_id": self.credentials.cluster,
+                "new_cluster": {
+                    "spark_version": "7.3.x-scala2.12",
+                    "node_type_id": "i3.xlarge",
+                    "spark_conf": {"spark.speculation": True},
+                    "aws_attributes": {"availability": "SPOT", "zone_id": "us-west-2a"},
+                    "autoscale": {"min_workers": 2, "max_workers": 4},
+                },
                 "notebook_task": {
                     "notebook_path": path,
                 },

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -2,9 +2,13 @@ import os
 import pytest
 from dbt.tests.util import run_dbt, write_file, run_dbt_and_capture
 from dbt.tests.adapter.python_model.test_python_model import BasePythonModelTests, BasePythonIncrementalTests
-
+from dbt.tests.adapter.python_model.test_spark import BasePySparkTests
 @pytest.mark.skip_profile("apache_spark", "spark_session", "databricks_sql_endpoint")
 class TestPythonModelSpark(BasePythonModelTests):
+    pass
+
+@pytest.mark.skip_profile("apache_spark", "spark_session", "databricks_sql_endpoint")
+class TestPySpark(BasePySparkTests):
     pass
 
 @pytest.mark.skip_profile("apache_spark", "spark_session", "databricks_sql_endpoint")


### PR DESCRIPTION
resolves #444 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description
<img width="760" alt="Screenshot 2022-09-22 at 6 15 44 PM" src="https://user-images.githubusercontent.com/17092660/191876425-3427e466-8e8b-4366-8e34-9a9b195067a7.png">
<img width="424" alt="Screenshot 2022-09-22 at 6 15 49 PM" src="https://user-images.githubusercontent.com/17092660/191876441-01580834-e0b0-4ba5-91cc-101878eddf0f.png">

When using notebook submission, if `job_cluster_config` is specified, we will run that model with a job_cluster.
This PR also makes user being able to specify a separate `cluster_id` or `job_cluster_config` for each individual model through config. 

`job_cluster_config` will overwrite `cluster_id` in current situation.(if `job_cluster_config` is set for a model, we will always use it).

This PR also removes the need for `user` and put dbt model files under `/dbt_python_mode/{$SCHEMA}` in Databricks workspace


<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
