### PR TITLE
try/except rather than find_spec for optional imports

### DIFF
--- a/dbt/include/spark/macros/materializations/table.sql
+++ b/dbt/include/spark/macros/materializations/table.sql
@@ -42,8 +42,6 @@
 dbt = dbtObj(spark.table)
 df = model(dbt, spark)
 
-import importlib.util
-
 # make sure pandas exists before using it
 try:
   import pandas

--- a/dbt/include/spark/macros/materializations/table.sql
+++ b/dbt/include/spark/macros/materializations/table.sql
@@ -44,24 +44,26 @@ df = model(dbt, spark)
 
 import importlib.util
 
-pandas_available = False
-pyspark_available = False
-koalas_available = False
-
 # make sure pandas exists before using it
-if importlib.util.find_spec("pandas"):
+try:
   import pandas
   pandas_available = True
+except ImportError:
+  pandas_available = False
 
 # make sure pyspark.pandas exists before using it
-if importlib.util.find_spec("pyspark.pandas"):
+try:
   import pyspark.pandas
   pyspark_available = True
+except ImportError:
+  pyspark_available = False
 
 # make sure databricks.koalas exists before using it
-if importlib.util.find_spec("databricks.koalas"):
+try:
   import databricks.koalas
   koalas_available = True
+except ImportError:
+  koalas_available = False
 
 # preferentially convert pandas DataFrames to pandas-on-Spark or Koalas DataFrames first
 # since they know how to convert pandas DataFrames better than `spark.createDataFrame(df)`


### PR DESCRIPTION
resolves #326

### Description

Uses the implementation [here](https://github.com/databricks/dbt-databricks/pull/196) by @ueshin.

There is a discussion [here](https://github.com/dbt-labs/dbt-spark/pull/474#discussion_r982414507) about how we could choose to optimize import load times in the future.

Choosing to ["make it right"](https://wiki.c2.com/?MakeItWorkMakeItRightMakeItFast) in this PR rather than ["make it fast"](https://wiki.c2.com/?MakeItWorkMakeItRightMakeItFast). (The performance cost for importing `pandas` was only ~1 second in local testing.)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
    - ⚠️ It would be great if we could add different test environments that do/don't have each of these libraries installed. In the meantime, we are just manually testing against environments that _do_ have them all available.
- [x] ~I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or~ docs changes are not required/relevant for this PR
- [x] ~I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)~
