### PR TITLE
Supports new error messages.

### DIFF
--- a/.changes/unreleased/Fixes-20221116-234601.yaml
+++ b/.changes/unreleased/Fixes-20221116-234601.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Support new error messages in the future Spark.
+time: 2022-11-16T23:46:01.899921861Z
+custom:
+  Author: ueshin
+  Issue: "515"
+  PR: "520"

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -226,7 +226,8 @@ class SparkAdapter(SQLAdapter):
             # spark would throw error when table doesn't exist, where other
             # CDW would just return and empty list, normalizing the behavior here
             errmsg = getattr(e, "msg", "")
-            if any(msg in errmsg for msg in TABLE_OR_VIEW_NOT_FOUND_MESSAGES):
+            found_msgs = (msg in errmsg for msg in TABLE_OR_VIEW_NOT_FOUND_MESSAGES)
+            if any(found_msgs):
                 pass
             else:
                 raise e

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -220,7 +220,14 @@ class SparkAdapter(SQLAdapter):
             # spark would throw error when table doesn't exist, where other
             # CDW would just return and empty list, normalizing the behavior here
             errmsg = getattr(e, "msg", "")
-            if "Table or view not found" in errmsg or "NoSuchTableException" in errmsg:
+            if any(
+                msg in errmsg
+                for msg in (
+                    "[TABLE_OR_VIEW_NOT_FOUND]",
+                    "Table or view not found",
+                    "NoSuchTableException",
+                )
+            ):
                 pass
             else:
                 raise e

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -43,6 +43,7 @@ TABLE_OR_VIEW_NOT_FOUND_MESSAGES = (
     "NoSuchTableException",
 )
 
+
 @dataclass
 class SparkConfig(AdapterConfig):
     file_format: str = "parquet"

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -37,6 +37,11 @@ FETCH_TBL_PROPERTIES_MACRO_NAME = "fetch_tbl_properties"
 KEY_TABLE_OWNER = "Owner"
 KEY_TABLE_STATISTICS = "Statistics"
 
+TABLE_OR_VIEW_NOT_FOUND_MESSAGES = (
+    "[TABLE_OR_VIEW_NOT_FOUND]",
+    "Table or view not found",
+    "NoSuchTableException",
+)
 
 @dataclass
 class SparkConfig(AdapterConfig):
@@ -220,14 +225,7 @@ class SparkAdapter(SQLAdapter):
             # spark would throw error when table doesn't exist, where other
             # CDW would just return and empty list, normalizing the behavior here
             errmsg = getattr(e, "msg", "")
-            if any(
-                msg in errmsg
-                for msg in (
-                    "[TABLE_OR_VIEW_NOT_FOUND]",
-                    "Table or view not found",
-                    "NoSuchTableException",
-                )
-            ):
+            if any(msg in errmsg for msg in TABLE_OR_VIEW_NOT_FOUND_MESSAGES):
                 pass
             else:
                 raise e


### PR DESCRIPTION
resolves #515


### Description

Supports new error messages.

In `SparkAdapter.get_columns_in_relation`, it checks the error message when the specified table or view doesn't exist:

https://github.com/dbt-labs/dbt-spark/blob/c87b6b2c48bcefb0ce52cd64984d3129d6f14ea0/dbt/adapters/spark/impl.py#L223

but, Spark will change the error message in the future release (https://github.com/apache/spark/pull/37887), which causes the function to raise the `dbt.exceptions.RuntimeException` instead of returning an empty list.

The function should also check whether the error message contains `[TABLE_OR_VIEW_NOT_FOUND]` or not.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
