### PR TITLE
[BACKPORT] manual backport/ modification of 520 to 1.0.latest

### DIFF
--- a/.changes/unreleased/Fixes-20221116-234601.yaml
+++ b/.changes/unreleased/Fixes-20221116-234601.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Support new error messages in the future Spark.
+time: 2022-11-16T23:46:01.899921861Z
+custom:
+  Author: ueshin
+  Issue: "515"
+  PR: "520"

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -244,7 +244,8 @@ class SparkAdapter(SQLAdapter):
                 columns = self.parse_describe_extended(relation, rows)
             except dbt.exceptions.RuntimeException as e:
                 # spark would throw error when table doesn't exist, where other
-                # CDW would just return and empty list, fixing the behavior here
+                # CDW would just return and empty list,
+                # we can normalize the behavior here
                 errmsg = getattr(e, "msg", "")
                 found_msgs = (
                     msg in errmsg for msg in TABLE_OR_VIEW_NOT_FOUND_MESSAGES

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -238,13 +238,17 @@ class SparkAdapter(SQLAdapter):
             # use get_columns_in_relation spark macro
             # which would execute 'describe extended tablename' query
             try:
-                rows: List[agate.Row] = super().get_columns_in_relation(relation)
+                rows: List[agate.Row] = super().get_columns_in_relation(
+                    relation
+                )
                 columns = self.parse_describe_extended(relation, rows)
             except dbt.exceptions.RuntimeException as e:
                 # spark would throw error when table doesn't exist, where other
                 # CDW would just return and empty list, normalizing the behavior here
                 errmsg = getattr(e, "msg", "")
-                found_msgs = (msg in errmsg for msg in TABLE_OR_VIEW_NOT_FOUND_MESSAGES)
+                found_msgs = (
+                    msg in errmsg for msg in TABLE_OR_VIEW_NOT_FOUND_MESSAGES
+                )
                 if any(found_msgs):
                     pass
                 else:

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -21,14 +21,20 @@ from dbt.utils import executor
 
 logger = AdapterLogger("Spark")
 
-GET_COLUMNS_IN_RELATION_MACRO_NAME = 'get_columns_in_relation'
-LIST_SCHEMAS_MACRO_NAME = 'list_schemas'
-LIST_RELATIONS_MACRO_NAME = 'list_relations_without_caching'
-DROP_RELATION_MACRO_NAME = 'drop_relation'
-FETCH_TBL_PROPERTIES_MACRO_NAME = 'fetch_tbl_properties'
+GET_COLUMNS_IN_RELATION_MACRO_NAME = "get_columns_in_relation"
+LIST_SCHEMAS_MACRO_NAME = "list_schemas"
+LIST_RELATIONS_MACRO_NAME = "list_relations_without_caching"
+DROP_RELATION_MACRO_NAME = "drop_relation"
+FETCH_TBL_PROPERTIES_MACRO_NAME = "fetch_tbl_properties"
 
-KEY_TABLE_OWNER = 'Owner'
-KEY_TABLE_STATISTICS = 'Statistics'
+KEY_TABLE_OWNER = "Owner"
+KEY_TABLE_STATISTICS = "Statistics"
+
+TABLE_OR_VIEW_NOT_FOUND_MESSAGES = (
+    "[TABLE_OR_VIEW_NOT_FOUND]",
+    "Table or view not found",
+    "NoSuchTableException",
+)
 
 
 @dataclass
@@ -231,8 +237,18 @@ class SparkAdapter(SQLAdapter):
             # return relation's schema. if columns are empty from cache,
             # use get_columns_in_relation spark macro
             # which would execute 'describe extended tablename' query
-            rows: List[agate.Row] = super().get_columns_in_relation(relation)
-            columns = self.parse_describe_extended(relation, rows)
+            try:
+                rows: List[agate.Row] = super().get_columns_in_relation(relation)
+                columns = self.parse_describe_extended(relation, rows)
+            except dbt.exceptions.RuntimeException as e:
+                # spark would throw error when table doesn't exist, where other
+                # CDW would just return and empty list, normalizing the behavior here
+                errmsg = getattr(e, "msg", "")
+                found_msgs = (msg in errmsg for msg in TABLE_OR_VIEW_NOT_FOUND_MESSAGES)
+                if any(found_msgs):
+                    pass
+                else:
+                    raise e
 
         # strip hudi metadata columns.
         columns = [x for x in columns

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -244,7 +244,7 @@ class SparkAdapter(SQLAdapter):
                 columns = self.parse_describe_extended(relation, rows)
             except dbt.exceptions.RuntimeException as e:
                 # spark would throw error when table doesn't exist, where other
-                # CDW would just return and empty list, normalizing the behavior here
+                # CDW would just return and empty list, fixing the behavior here
                 errmsg = getattr(e, "msg", "")
                 found_msgs = (
                     msg in errmsg for msg in TABLE_OR_VIEW_NOT_FOUND_MESSAGES


### PR DESCRIPTION
resolves #515 



### Description

manual backport of https://github.com/dbt-labs/dbt-spark/pull/520 with slight modification to make more relevant to state of 1.0.latest.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
