### PR TITLE
Adjust tox passenv to be multiline

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ skipsdist = True
 envlist = unit, flake8, integration-spark-thrift
 
 [testenv:{unit,py37,py38,py39,py310,py}]
+allowlist_externals =
+    /bin/bash
 commands = /bin/bash -c '{envpython} -m pytest -v {posargs} tests/unit'
 passenv =
     DBT_*

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,9 @@ envlist = unit, flake8, integration-spark-thrift
 
 [testenv:{unit,py37,py38,py39,py310,py}]
 commands = /bin/bash -c '{envpython} -m pytest -v {posargs} tests/unit'
-passenv = DBT_* PYTEST_ADDOPTS
+passenv =
+    DBT_*
+    PYTEST_ADDOPTS
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt
@@ -12,7 +14,9 @@ deps =
 [testenv:integration-spark-databricks-http]
 basepython = python3.8
 commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_http_cluster {posargs} -n4 tests/functional/adapter/*'
-passenv = DBT_* PYTEST_ADDOPTS
+passenv =
+    DBT_*
+    PYTEST_ADDOPTS
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt
@@ -22,7 +26,10 @@ deps =
 basepython = python3.8
 commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_cluster {posargs} -n4 tests/functional/adapter/*'
            /bin/bash -c '{envpython} -m pytest -v -m profile_databricks_cluster {posargs} -n4 tests/integration/*'
-passenv = DBT_* PYTEST_ADDOPTS ODBC_DRIVER
+passenv =
+    DBT_*
+    PYTEST_ADDOPTS
+    ODBC_DRIVER
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt
@@ -32,7 +39,10 @@ deps =
 basepython = python3.8
 commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_sql_endpoint {posargs} -n4 tests/functional/adapter/*'
            /bin/bash -c '{envpython} -m pytest -v -m profile_databricks_sql_endpoint {posargs} -n4 tests/integration/*'
-passenv = DBT_* PYTEST_ADDOPTS ODBC_DRIVER
+passenv =
+    DBT_*
+    PYTEST_ADDOPTS
+    ODBC_DRIVER
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt
@@ -43,7 +53,9 @@ deps =
 basepython = python3.8
 commands = /bin/bash -c '{envpython} -m pytest -v --profile apache_spark {posargs} -n4 tests/functional/adapter/*'
            /bin/bash -c '{envpython} -m pytest -v -m profile_apache_spark {posargs} -n4 tests/integration/*'
-passenv = DBT_* PYTEST_ADDOPTS
+passenv =
+    DBT_*
+    PYTEST_ADDOPTS
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt


### PR DESCRIPTION
https://github.com/dbt-labs/dbt-core/pull/6405 provides a fair amount of context


### Description
In tox 4, space-separated variables specified for passenv are not passed into the container.

```
[testenv:inline]
passenv = FOO BAR
☝️ doesn't work on tox 4
```

```
[testenv:separate-lines]
passenv =
    FOO
    BAR
```

- will need backport to at least 1.1.latest

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
