### PR TITLE
[BACKPORT] adding allowlist_externals for bash script to tox tests, changing passenv

### DIFF
--- a/.changes/unreleased/Under the Hood-20221209-143611.yaml
+++ b/.changes/unreleased/Under the Hood-20221209-143611.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: fix post new release tox issues around passenv and allowlist_externals
+time: 2022-12-09T14:36:11.005107-06:00
+custom:
+  Author: Mcknight-42
+  Issue: "546"
+  PR: "546"

--- a/tox.ini
+++ b/tox.ini
@@ -2,45 +2,66 @@
 skipsdist = True
 envlist = unit, flake8, integration-spark-thrift
 
-
 [testenv:flake8]
+allowlist_externals =
+    /bin/bash
 basepython = python3.8
 commands = /bin/bash -c '$(which flake8) --max-line-length 99 --select=E,W,F --ignore=W504 dbt/'
-passenv = DBT_* PYTEST_ADDOPTS
+passenv =
+    DBT_*
+    PYTEST_ADDOPTS
 deps =
      -r{toxinidir}/dev_requirements.txt
 
 [testenv:{unit,py37,py38,py39,py310,py}]
+allowlist_externals =
+    /bin/bash
 commands = /bin/bash -c '{envpython} -m pytest -v {posargs} tests/unit'
-passenv = DBT_* PYTEST_ADDOPTS
+passenv =
+    DBT_*
+    PYTEST_ADDOPTS
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
 
 [testenv:integration-spark-databricks-http]
+allowlist_externals =
+    /bin/bash
 basepython = python3.8
 commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_http_cluster {posargs} -n4 tests/functional/adapter/*'
-passenv = DBT_* PYTEST_ADDOPTS
+passenv =
+    DBT_*
+    PYTEST_ADDOPTS
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
     -e.
 
 [testenv:integration-spark-databricks-odbc-cluster]
+allowlist_externals =
+    /bin/bash
 basepython = python3.8
 commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_cluster {posargs} -n4 tests/functional/adapter/*'
            /bin/bash -c '{envpython} -m pytest -v -m profile_databricks_cluster {posargs} -n4 tests/integration/*'
-passenv = DBT_* PYTEST_ADDOPTS ODBC_DRIVER
+passenv =
+    DBT_*
+    PYTEST_ADDOPTS
+    ODBC_DRIVER
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
     -e.
 
 [testenv:integration-spark-databricks-odbc-sql-endpoint]
+allowlist_externals =
+    /bin/bash
 basepython = python3.8
 commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_sql_endpoint {posargs} -n4 tests/functional/adapter/*'
            /bin/bash -c '{envpython} -m pytest -v -m profile_databricks_sql_endpoint {posargs} -n4 tests/integration/*'
-passenv = DBT_* PYTEST_ADDOPTS ODBC_DRIVER
+passenv =
+    DBT_*
+    PYTEST_ADDOPTS
+    ODBC_DRIVER
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -48,16 +69,22 @@ deps =
 
 
 [testenv:integration-spark-thrift]
+allowlist_externals =
+    /bin/bash
 basepython = python3.8
 commands = /bin/bash -c '{envpython} -m pytest -v --profile apache_spark {posargs} -n4 tests/functional/adapter/*'
            /bin/bash -c '{envpython} -m pytest -v -m profile_apache_spark {posargs} -n4 tests/integration/*'
-passenv = DBT_* PYTEST_ADDOPTS
+passenv =
+    DBT_*
+    PYTEST_ADDOPTS
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
     -e.
 
 [testenv:integration-spark-session]
+allowlist_externals =
+    /bin/bash
 basepython = python3
 commands = /bin/bash -c '{envpython} -m pytest -v --profile spark_session {posargs} -n4 tests/functional/adapter/*'
 passenv =


### PR DESCRIPTION
…senv spacing

resolves #

updating 1.1.latest tox.ini file for post tox 4.0.0 release use

### Description

changing how `passenv` now has to have each variable on seperate line and adding `allowlist_externals` to allow for use of bash

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
