### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@
 name: Build, Test, and Package
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       sha:
         description: "The last commit sha in the release"
@@ -185,7 +185,7 @@ jobs:
     needs: build-test-package
 
     # pin to commit since this is workflow is WIP but this commit has been tested as working
-    uses: dbt-labs/dbt-release/.github/workflows/github-release.yml@7b6e01d
+    uses: dbt-labs/dbt-release/.github/workflows/github-release.yml@7b6e01d73d2c8454e06302cc66ef4c2dbd4dbe4e
 
     with:
       sha: ${{ inputs.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,118 +1,214 @@
-# Builds the spark plugin and releases it to GitHub and Pypi
-name: Build and Release
+# **what?**
+# Take the given commit, run unit tests specifically on that sha, build and
+# package it, and then release to GitHub with that specific build (PyPi to follow later)
+
+# **why?**
+# Ensure an automated and tested release process
+
+# **when?**
+# This will only run manually with a given sha and version
+
+name: Build, Test, and Package
 
 on:
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      sha:
+        description: "The last commit sha in the release"
+        type: string
+        required: true
+      changelog_path:
+        description: "Path to changes log"
+        type: string
+        default: "./CHANGELOG.md"
+        required: false
+      version_number:
+        description: "The release version number (i.e. 1.0.0b1)"
+        type: string
+        required: true
+      test_run:
+        description: "Test run (Publish release as draft to GitHub)"
+        type: boolean
+        default: false
+        required: false
 
-# Release version number that must be updated for each release
+permissions:
+  contents: write # this is the permission that allows creating a new release
+
 env:
-  version_number: '0.20.0rc2'
+  PYTHON_TARGET_VERSION: 3.8
+  ARTIFACT_RETENTION_DAYS: 2
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
-  Test:
+  log-inputs:
+    name: Log Inputs
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v2.2.2
-        with:
-          python-version: '3.8'
-
-      - uses: actions/checkout@v2
-
-      - name: Test release
+      - name: "[DEBUG] Print Variables"
         run: |
-          python3 -m venv env
-          source env/bin/activate
-          sudo apt-get install libsasl2-dev
-          pip install -r dev-requirements.txt
-          pip install twine wheel setuptools
-          python setup.py sdist bdist_wheel
-          pip install dist/dbt-spark-*.tar.gz
-          pip install dist/dbt_spark-*-py3-none-any.whl
-          twine check dist/dbt_spark-*-py3-none-any.whl dist/dbt-spark-*.tar.gz
+          echo The last commit sha in the release:  ${{ inputs.sha }}
+          echo The release version number:          ${{ inputs.version_number }}
+          echo The path to the changelog markdpown: ${{ inputs.changelog_path }}
+          echo This is a test run:                  ${{ inputs.test_run }}
+          echo Python target version:               ${{ env.PYTHON_TARGET_VERSION }}
+          echo Artifact retention days:             ${{ env.ARTIFACT_RETENTION_DAYS }}
 
-  GitHubRelease:
-    name: GitHub release
+  unit:
+    name: Unit Test
     runs-on: ubuntu-latest
-    needs: Test
+
+    env:
+      TOXENV: "unit"
+
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v2.2.2
+      - name: "Checkout Commit - ${{ inputs.sha }}"
+        uses: actions/checkout@v3
         with:
-          python-version: '3.8'
+          persist-credentials: false
+          ref: ${{ github.event.inputs.sha }}
 
-      - uses: actions/checkout@v2
+      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_TARGET_VERSION }}
 
-      - name: Bumping version
+      - name: "Install Python Dependencies"
         run: |
-          python3 -m venv env
-          source env/bin/activate
           sudo apt-get install libsasl2-dev
-          pip install -r dev-requirements.txt
-          bumpversion --config-file .bumpversion-dbt.cfg patch --new-version ${{env.version_number}}
-          bumpversion --config-file .bumpversion.cfg patch --new-version ${{env.version_number}} --allow-dirty
-          git status
+          python -m pip install --user --upgrade pip
+          python -m pip install tox
+          python -m pip --version
+          python -m tox --version
 
-      - name: Commit version bump and tag
-        uses: EndBug/add-and-commit@v7
-        with:
-          author_name: 'Leah Antkiewicz'
-          author_email: 'leah.antkiewicz@dbtlabs.com'
-          message: 'Bumping version to ${{env.version_number}}'
-          tag: v${{env.version_number}}
+      - name: "Run Tox"
+        run: tox
 
-      # Need to set an output variable because env variables can't be taken as input
-      # This is needed for the next step with releasing to GitHub
-      - name: Find release type
-        id: release_type
-        env:
-          IS_PRERELEASE: ${{ contains(env.version_number, 'rc') ||  contains(env.version_number, 'b') }}
-        run: |
-          echo ::set-output name=isPrerelease::$IS_PRERELEASE
+  build:
+    name: Build Packages
 
-      - name: Create GitHub release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: v${{env.version_number}}
-          release_name: dbt-spark v${{env.version_number}}
-          prerelease: ${{ steps.release_type.outputs.isPrerelease }}
-          body: |
-            Tracking [dbt-core v${{env.version_number}}](https://github.com/dbt-labs/dbt/releases/tag/v${{env.version_number}}).
-
-            ```sh
-            $ pip install dbt-spark==${{env.version_number}}
-            # or
-            $ pip install "dbt-spark[ODBC]==${{env.version_number}}"
-            # or
-            $ pip install "dbt-spark[PyHive]==${{env.version_number}}"
-            ```
-
-  PypiRelease:
-    name: Pypi release
     runs-on: ubuntu-latest
-    needs: GitHubRelease
-    environment: PypiProd
+
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v2.2.2
+      - name: "Checkout Commit - ${{ inputs.sha }}"
+        uses: actions/checkout@v3
         with:
-          python-version: '3.8'
+          persist-credentials: false
+          ref: ${{ inputs.sha }}
 
-      - uses: actions/checkout@v2
+      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+        uses: actions/setup-python@v4
         with:
-          ref: v${{env.version_number}}
+          python-version: ${{ env.PYTHON_TARGET_VERSION }}
 
-      - name: Release to pypi
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      - name: "Install Python Dependencies"
         run: |
-          python3 -m venv env
-          source env/bin/activate
           sudo apt-get install libsasl2-dev
-          pip install -r dev-requirements.txt
-          pip install twine wheel setuptools
-          python setup.py sdist bdist_wheel
-          twine upload --non-interactive dist/dbt_spark-${{env.version_number}}-py3-none-any.whl dist/dbt-spark-${{env.version_number}}.tar.gz
+          python -m pip install --user --upgrade pip
+          python -m pip install --upgrade setuptools wheel twine check-wheel-contents
+          python -m pip --version
+
+      - name: "Build Distributions"
+        run: ./scripts/build-dist.sh
+
+      - name: "[DEBUG] Show Distributions"
+        run: ls -lh dist/
+
+      - name: "Check Distribution Descriptions"
+        run: |
+          twine check dist/*
+
+      - name: "[DEBUG] Check Wheel Contents"
+        run: |
+          check-wheel-contents dist/*.whl --ignore W007,W008
+
+      - name: "Upload Build Artifact - ${{ inputs.version_number }}"
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.version_number }}
+          path: |
+            dist/
+            !dist/dbt-${{ inputs.version_number }}.tar.gz
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+
+  test-build:
+    name: Verify Packages
+
+    needs: [unit, build]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_TARGET_VERSION }}
+
+      - name: "Install Python Dependencies"
+        run: |
+          sudo apt-get install libsasl2-dev
+          python -m pip install --user --upgrade pip
+          python -m pip install --upgrade wheel
+          python -m pip --version
+
+      - name: "Download Build Artifact - ${{ inputs.version_number }}"
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.version_number }}
+          path: dist/
+
+      - name: "[DEBUG] Show Distributions"
+        run: ls -lh dist/
+
+      - name: "Install Wheel Distributions"
+        run: |
+          find ./dist/*.whl -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
+
+      - name: "[DEBUG] Check Wheel Distributions"
+        run: |
+          dbt --version
+
+      - name: "Install Source Distributions"
+        run: |
+          find ./dist/*.gz -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
+
+      - name: "[DEBUG] Check Source Distributions"
+        run: |
+          dbt --version
+
+  github-release:
+    name: GitHub Release
+    if: ${{ !failure() && !cancelled() }}
+    needs: build-test-package
+
+    # pin to commit since this is workflow is WIP but this commit has been tested as working
+    uses: dbt-labs/dbt-release/.github/workflows/github-release.yml@7b6e01d
+
+    with:
+      sha: ${{ inputs.sha }}
+      version_number: ${{ inputs.version_number }}
+      changelog_path: ${{ inputs.changelog_path }}
+      test_run: ${{ inputs.test_run }}
+
+# Skipping this for now until we've proven build work in the repos
+  # pypi-release:
+  #   name: Pypi release
+
+  #   runs-on: ubuntu-latest
+
+  #   needs: github-release
+
+  #   environment: PypiProd
+  #   steps:
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: dist
+  #         path: 'dist'
+
+  #     - name: Publish distribution to PyPI
+  #       uses: pypa/gh-action-pypi-publish@v1.4.2
+  #       with:
+  #         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
   github-release:
     name: GitHub Release
     if: ${{ !failure() && !cancelled() }}
-    needs: build-test-package
+    needs: test-build
 
     # pin to commit since this is workflow is WIP but this commit has been tested as working
     uses: dbt-labs/dbt-release/.github/workflows/github-release.yml@7b6e01d73d2c8454e06302cc66ef4c2dbd4dbe4e


### PR DESCRIPTION
resolves #549 

### Description

Automates the build and release to GitHub and PyPi. The version_bump.yml needs to be run manually first.

This is specifically for the beta release. If it fails we will need to fall back to manually releasing as we have in the past per [this notion doc](https://www.notion.so/dbtlabs/Upload-Artifacts-to-Pypi-and-github-release-d246229c17c34ccaa5b6b29da32a3c9f)

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
