### PR TITLE
Added server side parameters for thrift connection type

### DIFF
--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -378,7 +378,7 @@ class SparkConnectionManager(SQLConnectionManager):
                             kerberos_service_name=creds.kerberos_service_name,
                             password=creds.password,
                         )
-                        conn = hive.connect(thrift_transport=transport)
+                        conn = hive.connect(thrift_transport=transport, configuration=creds.server_side_parameters)
                     else:
                         conn = hive.connect(
                             host=creds.host,
@@ -387,6 +387,7 @@ class SparkConnectionManager(SQLConnectionManager):
                             auth=creds.auth,
                             kerberos_service_name=creds.kerberos_service_name,
                             password=creds.password,
+                            configuration=creds.server_side_parameters
                         )  # noqa
                     handle = PyhiveConnectionWrapper(conn)
                 elif creds.method == SparkConnectionMethod.ODBC:

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -154,13 +154,14 @@ class TestSparkAdapter(unittest.TestCase):
         config = self._get_target_thrift(self.project_cfg)
         adapter = SparkAdapter(config)
 
-        def hive_thrift_connect(host, port, username, auth, kerberos_service_name, password):
+        def hive_thrift_connect(host, port, username, auth, kerberos_service_name, password, configuration):
             self.assertEqual(host, 'myorg.sparkhost.com')
             self.assertEqual(port, 10001)
             self.assertEqual(username, 'dbt')
             self.assertIsNone(auth)
             self.assertIsNone(kerberos_service_name)
             self.assertIsNone(password)
+            self.assertDictEqual(configuration, {})
 
         with mock.patch.object(hive, 'connect', new=hive_thrift_connect):
             connection = adapter.acquire_connection('dummy')
@@ -175,11 +176,12 @@ class TestSparkAdapter(unittest.TestCase):
         config = self._get_target_use_ssl_thrift(self.project_cfg)
         adapter = SparkAdapter(config)
 
-        def hive_thrift_connect(thrift_transport):
+        def hive_thrift_connect(thrift_transport, configuration):
             self.assertIsNotNone(thrift_transport)
             transport = thrift_transport._trans
             self.assertEqual(transport.host, 'myorg.sparkhost.com')
             self.assertEqual(transport.port, 10001)
+            self.assertDictEqual(configuration, {})
 
         with mock.patch.object(hive, 'connect', new=hive_thrift_connect):
             connection = adapter.acquire_connection('dummy')
@@ -194,13 +196,14 @@ class TestSparkAdapter(unittest.TestCase):
         config = self._get_target_thrift_kerberos(self.project_cfg)
         adapter = SparkAdapter(config)
 
-        def hive_thrift_connect(host, port, username, auth, kerberos_service_name, password):
+        def hive_thrift_connect(host, port, username, auth, kerberos_service_name, password, configuration):
             self.assertEqual(host, 'myorg.sparkhost.com')
             self.assertEqual(port, 10001)
             self.assertEqual(username, 'dbt')
             self.assertEqual(auth, 'KERBEROS')
             self.assertEqual(kerberos_service_name, 'hive')
             self.assertIsNone(password)
+            self.assertDictEqual(configuration, {})
 
         with mock.patch.object(hive, 'connect', new=hive_thrift_connect):
             connection = adapter.acquire_connection('dummy')
@@ -734,4 +737,3 @@ class TestSparkAdapter(unittest.TestCase):
             'stats:rows:label': 'rows',
             'stats:rows:value': 12345678
         })
-


### PR DESCRIPTION
resolves #387

### Description

PR allows passing spark/hive configurations for thrift connections via server_side_parameters in the profiles file.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
