### PR TITLE
Use CircleCI Context for AWS access key environment variables

### DIFF
--- a/.changes/unreleased/Under the Hood-20230105-182038.yaml
+++ b/.changes/unreleased/Under the Hood-20230105-182038.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Use CircleCI Context for AWS access key environment variables
+time: 2023-01-05T18:20:38.48148-07:00
+custom:
+  Author: dbeatty10
+  Issue: "581"
+  PR: "581"

--- a/.changes/unreleased/Under the Hood-20230105-182038.yaml
+++ b/.changes/unreleased/Under the Hood-20230105-182038.yaml
@@ -1,7 +1,0 @@
-kind: Under the Hood
-body: Use CircleCI Context for AWS access key environment variables
-time: 2023-01-05T18:20:38.48148-07:00
-custom:
-  Author: dbeatty10
-  Issue: "581"
-  PR: "581"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,10 +125,10 @@ workflows:
           requires:
             - integration-spark-thrift
       - integration-spark-databricks-odbc-cluster:
-          context: org-global
+          context: aws-credentials
           requires:
             - integration-spark-thrift
       - integration-spark-databricks-odbc-endpoint:
-          context: org-global
+          context: aws-credentials
           requires:
             - integration-spark-thrift

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,8 +125,10 @@ workflows:
           requires:
             - integration-spark-thrift
       - integration-spark-databricks-odbc-cluster:
+          context: org-global
           requires:
             - integration-spark-thrift
       - integration-spark-databricks-odbc-endpoint:
+          context: org-global
           requires:
             - integration-spark-thrift

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps =
 allowlist_externals =
     /bin/bash
 basepython = python3.8
-commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_sql_endpoint {posargs}  -n4 tests/functional/adapter/*'
+commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_sql_endpoint {posargs} -n4 tests/functional/adapter/*'
            /bin/bash -c '{envpython} -m pytest -v -m profile_databricks_sql_endpoint {posargs} -n4 tests/integration/*'
 passenv =
     DBT_*


### PR DESCRIPTION
resolves #581


### Description

Use a [CircleCI Context](https://circleci.com/docs/contexts/) for AWS access key environment variables.

### Details

The names of contexts within CircleCI are chosen by the user, and they act like a named group of environment variables that can be "imported" within `workflows` so that the individual environment variables can be used within `jobs`.

In this case, we know that the name we gave this context is `aws-credentials`, and we can look it up here:
https://app.circleci.com/settings/organization/github/dbt-labs/contexts

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] ~This PR includes tests, or~ tests are not required/relevant for this PR
- [x] ~I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or~ docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
