### PR TITLE
add release prep secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,7 @@ jobs:
       env_setup_script_path: ""
       test_run: ${{ inputs.test_run }}
 
-    secrets:
-      FISHTOWN_BOT_PAT: ${{ secrets.FISHTOWN_BOT_PAT }}
+    secrets: inherit
 
   log-outputs-audit-version-and-changelog:
     name: "[Log output] Bump package version, Generate changelog"


### PR DESCRIPTION
### Description

The release currently fails because IT_TEAM_MEMBERSHIP secret is not being passed in to the release-prep workflow.  This was an oversight in a previous update to add core team automation because while the release-prep workflow defines the secret, dbt-spark doesn't actually _use_ the secret right now.  This is because `dbt-spark` is still on CircleCI and so the release-prep workflow just makes sure the version is already bumped and changelog exists.  It does not trigger the version bump and changelog generation itself.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
