### PR TITLE
Cleanup main after cutting new 1.5.latest branch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.0b2
+current_version = 1.6.0a1
 parse = (?P<major>[\d]+) # major version number
 	\.(?P<minor>[\d]+) # minor version number
 	\.(?P<patch>[\d]+) # patch version number
@@ -7,7 +7,7 @@ parse = (?P<major>[\d]+) # major version number
 	?(?P<num>[\d]+?)) # optional pre-release version number
 	\.?(?P<nightly>[a-z0-9]+\+[a-z]+)? # optional nightly release indicator
 	)? # expected matches: `1.5.0`, `1.5.0a1`, `1.5.0a1.dev123457+nightly`, expected failures: `1`, `1.5`, `1.5.2-a1`, `text1.5.0`
-serialize =
+serialize = 
 	{major}.{minor}.{patch}{prekind}{num}.{nightly}
 	{major}.{minor}.{patch}{prekind}{num}
 	{major}.{minor}.{patch}
@@ -17,7 +17,7 @@ tag = False
 [bumpversion:part:prekind]
 first_value = a
 optional_value = final
-values =
+values = 
 	a
 	b
 	rc

--- a/.changes/unreleased/Features-20230223-180923.yaml
+++ b/.changes/unreleased/Features-20230223-180923.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: implement data_type_code_to_name on SparkConnectionManager
-time: 2023-02-23T18:09:23.787675-05:00
-custom:
-  Author: michelleark
-  Issue: "639"

--- a/.changes/unreleased/Fixes-20230303-200542.yaml
+++ b/.changes/unreleased/Fixes-20230303-200542.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: 'Fix pyodbc type_code -> data_type conversion '
-time: 2023-03-03T20:05:42.400255-05:00
-custom:
-  Author: michelleark
-  Issue: "665"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 ### Contributors
 - [@dparent1](https://github.com/dparent1) ([#294](https://github.com/dbt-labs/dbt-spark/issues/294))
 
-
 ## dbt-spark 1.5.0-b1 - February 22, 2023
 
 ### Features
@@ -51,3 +50,4 @@ For information on prior major and minor releases, see their changelogs:
 - [0.21](https://github.com/dbt-labs/dbt-spark/blob/0.21.latest/CHANGELOG.md)
 - [0.20](https://github.com/dbt-labs/dbt-spark/blob/0.20.latest/CHANGELOG.md)
 - [0.19 and earlier](https://github.com/dbt-labs/dbt-spark/blob/0.19.latest/CHANGELOG.md)
+

--- a/dbt/adapters/spark/__version__.py
+++ b/dbt/adapters/spark/__version__.py
@@ -1,1 +1,1 @@
-version = "1.5.0b2"
+version = "1.6.0a1"

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def _get_dbt_core_version():
 
 
 package_name = "dbt-spark"
-package_version = "1.5.0b2"
+package_version = "1.6.0a1"
 dbt_core_version = _get_dbt_core_version()
 description = """The Apache Spark adapter plugin for dbt"""
 


### PR DESCRIPTION
This PR will fail CI until the dbt-core PR has been merged due to release version conflicts. The workflow that generated this PR also created a new branch: 1.5.latest