### PR TITLE
ADAP-473: Table materialization not properly dropping existing relation on refresh

### DIFF
--- a/.changes/unreleased/Fixes-20230420-214433.yaml
+++ b/.changes/unreleased/Fixes-20230420-214433.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixed issue where table materialization was not always properly refreshing for non-admin users on Databricks
+time: 2023-04-20T21:44:33.343598-04:00
+custom:
+  Author: mikealfare
+  Issue: "725"

--- a/dbt/include/spark/macros/materializations/table.sql
+++ b/dbt/include/spark/macros/materializations/table.sql
@@ -17,13 +17,16 @@
   {% if old_relation is not none %}
     {% set is_delta = (old_relation.is_delta and config.get('file_format', validator=validation.any[basestring]) == 'delta') %}
     {% set is_iceberg = (old_relation.is_iceberg and config.get('file_format', validator=validation.any[basestring]) == 'iceberg') %}
+    {% set old_relation_type = old_relation.type %}
   {% else %}
     {% set is_delta = false %}
     {% set is_iceberg = false %}
+    {% set old_relation_type = target_relation.type %}
   {% endif %}
 
   {% if not is_delta and not is_iceberg %}
-    {{ adapter.drop_relation(target_relation) }}
+    {% set existing_relation = target_relation %}
+    {{ adapter.drop_relation(existing_relation.incorporate(type=old_relation_type)) }}
   {% endif %}
 
   -- build model

--- a/dbt/include/spark/macros/materializations/table.sql
+++ b/dbt/include/spark/macros/materializations/table.sql
@@ -14,16 +14,19 @@
   -- setup: if the target relation already exists, drop it
   -- in case if the existing and future table is delta or iceberg, we want to do a
   -- create or replace table instead of dropping, so we don't have the table unavailable
-  {% if old_relation and not (old_relation.is_delta and config.get('file_format', validator=validation.any[basestring]) == 'delta') -%}
-    {{ adapter.drop_relation(old_relation) }}
-  {%- endif %}
+  {% if old_relation is not none %}
+    {% set is_delta = (old_relation.is_delta and config.get('file_format', validator=validation.any[basestring]) == 'delta') %}
+    {% set is_iceberg = (old_relation.is_iceberg and config.get('file_format', validator=validation.any[basestring]) == 'iceberg') %}
+  {% else %}
+    {% set is_delta = false %}
+    {% set is_iceberg = false %}
+  {% endif %}
 
-  {% if old_relation and not (old_relation.is_iceberg and config.get('file_format', validator=validation.any[basestring]) == 'iceberg') -%}
-    {{ adapter.drop_relation(old_relation) }}
-  {%- endif %}
+  {% if not is_delta and not is_iceberg %}
+    {{ adapter.drop_relation(target_relation) }}
+  {% endif %}
 
   -- build model
-
   {%- call statement('main', language=language) -%}
     {{ create_table_as(False, target_relation, compiled_code, language) }}
   {%- endcall -%}


### PR DESCRIPTION
resolves #725 

### Description

We were not properly dropping an existing table relation when that model was refreshed using a non-admin account in Databricks. That prevented us from refreshing those models, as the non-admin account could not see the already existing tables, hence could not overwrite them. The original workaround was to elevate the service account to be an admin, but this was deemed too steep of a requirement. The solution that worked in the end was to update the table materialization itself, and drop the `target_relation` instead of the `old_relation`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
