### PR TITLE
Update pytest requirement from ~=7.2 to ~=7.3

### DIFF
--- a/.changes/unreleased/Dependencies-20230421-041623.yaml
+++ b/.changes/unreleased/Dependencies-20230421-041623.yaml
@@ -1,0 +1,6 @@
+kind: "Dependencies"
+body: "Update pytest requirement from ~=7.2 to ~=7.3"
+time: 2023-04-21T04:16:23.00000Z
+custom:
+  Author: mikealfare
+  PR: 726

--- a/.changes/unreleased/Dependencies-20230421-041627.yaml
+++ b/.changes/unreleased/Dependencies-20230421-041627.yaml
@@ -1,0 +1,6 @@
+kind: "Dependencies"
+body: "Update pytest requirement from ~=7.2 to ~=7.3"
+time: 2023-04-21T04:16:27.00000Z
+custom:
+  Author: mikealfare
+  PR: 726

--- a/.changes/unreleased/Dependencies-20230421-041627.yaml
+++ b/.changes/unreleased/Dependencies-20230421-041627.yaml
@@ -1,6 +1,0 @@
-kind: "Dependencies"
-body: "Update pytest requirement from ~=7.2 to ~=7.3"
-time: 2023-04-21T04:16:27.00000Z
-custom:
-  Author: mikealfare
-  PR: 726

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,7 +18,7 @@ pip-tools~=6.12
 pre-commit~=2.21;python_version=="3.7"
 pre-commit~=3.2;python_version>="3.8"
 pre-commit-hooks~=4.4
-pytest~=7.2
+pytest~=7.3
 pytest-csv~=3.0
 pytest-dotenv~=0.5.2
 pytest-logbook~=1.2


### PR DESCRIPTION
### Description

Upgrade `pytest` to `~=7.3` to align with other adapters and dependabot.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
