### PR TITLE
Allow hostname to be provided with or without a trailing slash

### DIFF
--- a/.changes/unreleased/Fixes-20230623-112100.yaml
+++ b/.changes/unreleased/Fixes-20230623-112100.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Allow hostname to be provided with or without trailing slash
+time: 2023-06-23T11:21:00.901430172Z
+custom:
+  Author: tim-steinkuhler
+  Issue: "302"

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -140,6 +140,9 @@ class SparkCredentials(Credentials):
                     f"ImportError({e.msg})"
                 ) from e
 
+        if self.method != SparkConnectionMethod.SESSION:
+            self.host = self.host.rstrip("/")
+
     @property
     def type(self):
         return "spark"


### PR DESCRIPTION
resolves #302

### Description

Allow hostname to be provided with or without trailing slash

When you copy in the hostname, it may or may not include trailing `/`
We could avoid confusion by allowing users to include or exclude these elements.


Before this change, `dbt debug` would get you something like this:
```
dbt was unable to connect to the specified database.
The database returned the following error:

  >Runtime Error
  Database Error
    failed to connect
```

Output while using a trailing slash after change (given credentials are correct):
```
Connection test: [OK connection ok]
```


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
