### PR TITLE
Standardize the adapter for core debug changes

### DIFF
--- a/.changes/unreleased/Features-20230604-043421.yaml
+++ b/.changes/unreleased/Features-20230604-043421.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Standardize the _connection_keys and debug_query for `dbt debug`.
+time: 2023-06-04T04:34:21.968669-07:00
+custom:
+  Author: versusfacit
+  Issue: PR754

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -148,7 +148,27 @@ class SparkCredentials(Credentials):
         return self.host
 
     def _connection_keys(self):
-        return ("host", "port", "cluster", "endpoint", "schema", "organization")
+        return (
+            "host",
+            "port",
+            "cluster",
+            "endpoint",
+            "schema",
+            "organization",
+            "method",
+            "database",
+            "driver",
+            "token",
+            "user",
+            "password",
+            "auth",
+            "kerberos_service_name",
+            "connect_retries",
+            "connect_timeout",
+            "use_ssl",
+            "server_side_parameters",
+            "retry_all",
+        )
 
 
 class PyhiveConnectionWrapper(object):

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -149,27 +149,7 @@ class SparkCredentials(Credentials):
         return self.host
 
     def _connection_keys(self) -> Tuple[str, ...]:
-        return (
-            "host",
-            "port",
-            "cluster",
-            "endpoint",
-            "schema",
-            "organization",
-            "method",
-            "database",
-            "driver",
-            "token",
-            "user",
-            "password",
-            "auth",
-            "kerberos_service_name",
-            "connect_retries",
-            "connect_timeout",
-            "use_ssl",
-            "server_side_parameters",
-            "retry_all",
-        )
+        return ("host", "port", "cluster", "endpoint", "schema", "organization")
 
 
 class PyhiveConnectionWrapper(object):

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from typing import Tuple
 
 import dbt.exceptions
 from dbt.adapters.base import Credentials
@@ -147,7 +148,7 @@ class SparkCredentials(Credentials):
     def unique_field(self):
         return self.host
 
-    def _connection_keys(self):
+    def _connection_keys(self) -> Tuple[str, ...]:
         return (
             "host",
             "port",

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -479,7 +479,7 @@ class SparkAdapter(SQLAdapter):
 
     def debug_query(self):
         """Override for DebugTask method"""
-        self.execute("selecta 1 as id")
+        self.execute("select 1 as id")
 
 
 # spark does something interesting with joins when both tables have the same

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -477,6 +477,10 @@ class SparkAdapter(SQLAdapter):
                     grants_dict.update({privilege: [grantee]})
         return grants_dict
 
+    def debug_query(self):
+        """Override for DebugTask method"""
+        self.execute("selecta 1 as id")
+
 
 # spark does something interesting with joins when both tables have the same
 # static values for the join condition and complains that the join condition is

--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -21,6 +21,7 @@ from dbt.tests.adapter.utils.test_position import BasePosition
 from dbt.tests.adapter.utils.test_replace import BaseReplace
 from dbt.tests.adapter.utils.test_right import BaseRight
 from dbt.tests.adapter.utils.test_safe_cast import BaseSafeCast
+
 from dbt.tests.adapter.utils.test_split_part import BaseSplitPart
 from dbt.tests.adapter.utils.test_string_literal import BaseStringLiteral
 
@@ -28,6 +29,19 @@ from dbt.tests.adapter.utils.test_string_literal import BaseStringLiteral
 from dbt.tests.adapter.utils.test_listagg import BaseListagg
 from dbt.tests.adapter.utils.fixture_listagg import models__test_listagg_yml
 from tests.functional.adapter.utils.fixture_listagg import models__test_listagg_no_order_by_sql
+
+seeds__data_split_part_csv = """parts,split_on,result_1,result_2,result_3
+a|b|c,|,a,b,c
+1|2|3,|,1,2,3
+EMPTY|EMPTY|EMPTY,|,EMPTY,EMPTY,EMPTY
+"""
+
+seeds__data_last_day_csv = """date_day,date_part,result
+2018-01-02,month,2018-01-31
+2018-01-02,quarter,2018-03-31
+2018-01-02,year,2018-12-31
+"""
+# skipped: ,month,
 
 
 class TestAnyValue(BaseAnyValue):
@@ -96,7 +110,9 @@ class TestIntersect(BaseIntersect):
 
 
 class TestLastDay(BaseLastDay):
-    pass
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"data_last_day.csv": seeds__data_last_day_csv}
 
 
 class TestLength(BaseLength):
@@ -135,7 +151,9 @@ class TestSafeCast(BaseSafeCast):
 
 
 class TestSplitPart(BaseSplitPart):
-    pass
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"data_split_part.csv": seeds__data_split_part_csv}
 
 
 class TestStringLiteral(BaseStringLiteral):


### PR DESCRIPTION
PR to bring adapter in parity with [this core PR](https://github.com/dbt-labs/dbt-core/pull/7741).

I confirmed this `debug_query` does work. But, `_connection_keys` does not. I think we need to filter what params make it to the connection phase in core. That requires further scoping. After this is merged, I'll make a followup option.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
