### PR TITLE
Remove dependent_projects argument from PartialProject call in unit tests

### DIFF
--- a/.changes/unreleased/Fixes-20230628-162413.yaml
+++ b/.changes/unreleased/Fixes-20230628-162413.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove dependent_projects argument from PartialProject call in unit tests
+time: 2023-06-28T16:24:13.288246-05:00
+custom:
+  Author: McKnight-42
+  Issue: "7955"

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -75,7 +75,6 @@ def project_from_dict(project, profile, packages=None, selectors=None, cli_vars=
         project_root=project_root,
         project_dict=project,
         packages_dict=packages,
-        dependent_projects_dict={},
         selectors_dict=selectors,
     )
     return partial.render(renderer)


### PR DESCRIPTION
resolves #https://github.com/dbt-labs/dbt-core/pull/7955

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-spark/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
