### PR TITLE
add datadog env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run: python3 -m pip install tox
       - run:
           name: Run integration tests
-          command: tox -e integration-spark-session
+          command: tox -e integration-spark-session -- --ddtrace
           no_output_timeout: 1h
       - store_artifacts:
           path: ./logs
@@ -54,7 +54,7 @@ jobs:
 
       - run:
           name: Run integration tests
-          command: tox -e integration-spark-thrift
+          command: tox -e integration-spark-thrift -- --ddtrace
           no_output_timeout: 1h
       - store_artifacts:
           path: ./logs
@@ -72,7 +72,7 @@ jobs:
       - checkout
       - run:
           name: Run integration tests
-          command: tox -e integration-spark-databricks-http
+          command: tox -e integration-spark-databricks-http -- --ddtrace
           no_output_timeout: 1h
       - store_artifacts:
           path: ./logs
@@ -94,7 +94,7 @@ jobs:
       - checkout
       - run:
           name: Run integration tests
-          command: tox -e integration-spark-databricks-odbc-cluster
+          command: tox -e integration-spark-databricks-odbc-cluster -- --ddtrace
           no_output_timeout: 1h
       - store_artifacts:
           path: ./logs
@@ -105,7 +105,7 @@ jobs:
       - checkout
       - run:
           name: Run integration tests
-          command: tox -e integration-spark-databricks-odbc-sql-endpoint
+          command: tox -e integration-spark-databricks-odbc-sql-endpoint -- --ddtrace
           no_output_timeout: 1h
       - store_artifacts:
           path: ./logs

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,6 +8,7 @@ git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=
 black~=23.3
 bumpversion~=0.6.0
 click~=8.1
+ddtrace~=1.16
 flake8~=6.0;python_version>="3.8"
 flaky~=3.7
 freezegun~=1.2

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ commands = /bin/bash -c '{envpython} -m pytest -v --profile databricks_http_clus
 passenv =
     DBT_*
     PYTEST_ADDOPTS
+    DD_SERVICE
+    DD_ENV
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt
@@ -35,6 +37,8 @@ passenv =
     DBT_*
     PYTEST_ADDOPTS
     ODBC_DRIVER
+    DD_SERVICE
+    DD_ENV
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt
@@ -49,6 +53,8 @@ passenv =
     DBT_*
     PYTEST_ADDOPTS
     ODBC_DRIVER
+    DD_SERVICE
+    DD_ENV
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt
@@ -63,6 +69,8 @@ commands = /bin/bash -c '{envpython} -m pytest -v --profile apache_spark {posarg
 passenv =
     DBT_*
     PYTEST_ADDOPTS
+    DD_SERVICE
+    DD_ENV
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt
@@ -77,6 +85,8 @@ passenv =
     DBT_*
     PYTEST_*
     PIP_CACHE_DIR
+    DD_SERVICE
+    DD_ENV
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt


### PR DESCRIPTION
resolves #8081 
~~[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#~~ n/a

### Problem

Datadog not ingesting test data for flaky test visibility

### Solution

Adds env vars to turn on test visibility in datadog.  [Datadog docs](https://docs.datadoghq.com/continuous_integration/tests/python/?tab=cloudciprovideragentless#compatibility)

Updates the tox command to include the `--ddtrace` flag only when running in CI.

### Pending
Update CircleCI: https://docs.datadoghq.com/continuous_integration/pipelines/circleci/

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX