### PR TITLE
Update adaptors.sql to use `tblproperties` macro

### DIFF
--- a/.changes/unreleased/Fixes-20230810-014122.yaml
+++ b/.changes/unreleased/Fixes-20230810-014122.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: include tblproperties macro in adaptors
+time: 2023-08-10T01:41:22.782982+08:00
+custom:
+  Author: etheleon
+  Issue: "865"

--- a/.changes/unreleased/Fixes-20230810-014122.yaml
+++ b/.changes/unreleased/Fixes-20230810-014122.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: include tblproperties macro in adaptor.sql
+body: include tblproperties macro in adapters.sql create table
 time: 2023-08-10T01:41:22.782982+08:00
 custom:
   Author: etheleon

--- a/.changes/unreleased/Fixes-20230810-014122.yaml
+++ b/.changes/unreleased/Fixes-20230810-014122.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: include tblproperties macro in adaptors
+body: include tblproperties macro in adaptor.sql
 time: 2023-08-10T01:41:22.782982+08:00
 custom:
   Author: etheleon

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -1,4 +1,8 @@
-{% macro dbt_spark_tblproperties_clause() -%}
+{% macro tblproperties_clause() %}
+  {{ return(adapter.dispatch('tblproperties_clause', 'dbt')()) }}
+{%- endmacro -%}
+
+{% macro spark__tblproperties_clause() -%}
   {%- set tblproperties = config.get('tblproperties') -%}
   {%- if tblproperties is not none %}
     tblproperties (

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -160,10 +160,12 @@
       {% endif %}
       {{ file_format_clause() }}
       {{ options_clause() }}
+      {{ tblproperties_clause() }}
       {{ partition_cols(label="partitioned by") }}
       {{ clustered_cols(label="clustered by") }}
       {{ location_clause() }}
       {{ comment_clause() }}
+
       as
       {{ compiled_code }}
     {%- endif -%}

--- a/dbt/include/spark/macros/materializations/seed.sql
+++ b/dbt/include/spark/macros/materializations/seed.sql
@@ -69,6 +69,7 @@
     {{ clustered_cols(label="clustered by") }}
     {{ location_clause() }}
     {{ comment_clause() }}
+    {{ tblproperties_clause() }}
   {% endset %}
 
   {% call statement('_') -%}

--- a/dbt/include/spark/macros/materializations/seed.sql
+++ b/dbt/include/spark/macros/materializations/seed.sql
@@ -69,7 +69,7 @@
     {{ clustered_cols(label="clustered by") }}
     {{ location_clause() }}
     {{ comment_clause() }}
-    {{ dbt_spark_tblproperties_clause() }}
+    {{ tblproperties_clause() }}
   {% endset %}
 
   {% call statement('_') -%}

--- a/dbt/include/spark/macros/materializations/seed.sql
+++ b/dbt/include/spark/macros/materializations/seed.sql
@@ -69,7 +69,6 @@
     {{ clustered_cols(label="clustered by") }}
     {{ location_clause() }}
     {{ comment_clause() }}
-    {{ tblproperties_clause() }}
   {% endset %}
 
   {% call statement('_') -%}

--- a/dbt/include/spark/macros/materializations/seed.sql
+++ b/dbt/include/spark/macros/materializations/seed.sql
@@ -69,7 +69,7 @@
     {{ clustered_cols(label="clustered by") }}
     {{ location_clause() }}
     {{ comment_clause() }}
-    {{ tblproperties_clause() }}
+    {{ dbt_spark_tblproperties_clause() }}
   {% endset %}
 
   {% call statement('_') -%}


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

`tblproperties` clause macro is not used when creating tables. Add macro to adaptor.sql  

### Solution

Add macro 

### Checklist

- [ x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
