### PR TITLE
Include missing `tblproperties_clause()`.

### DIFF
--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -1,4 +1,4 @@
-{% macro dbt_spark_tblproperties_clause() -%}
+{% macro spark__tblproperties_clause() -%}
   {%- set tblproperties = config.get('tblproperties') -%}
   {%- if tblproperties is not none %}
     tblproperties (
@@ -7,6 +7,10 @@
       {%- endfor %}
     )
   {%- endif %}
+{%- endmacro -%}
+
+{% macro tblproperties_clause() -%}
+  {{ return(adapter.dispatch('tblproperties_clause', 'dbt')()) }}
 {%- endmacro -%}
 
 {% macro file_format_clause() %}
@@ -156,6 +160,7 @@
       {% endif %}
       {{ file_format_clause() }}
       {{ options_clause() }}
+      {{ tblproperties_clause() }}
       {{ partition_cols(label="partitioned by") }}
       {{ clustered_cols(label="clustered by") }}
       {{ location_clause() }}


### PR DESCRIPTION
The call to `tblproperties_clause()` is missing in the "CREATE TABLE" statement building.
This is needed in order to be able to use DBT-Spark on top of Iceberg/S3, as we need to pass parameters at table creation time.


### Problem

When creating tables on Spark/Iceberg/S3, DBT will not honor the `TBLPROPERTIES` defined in the config.
There are various properties that need to be set at `CREATE TABLE` time. In my particular case, I need
to enable `write.object-storage.enabled` to avoid being throttled by AWS S3.
### Solution

By including the call to `tblproperties_clause` inside the macro `spark__create_table_as`, the properties
will be included in the `CREATE TABLE` statement, thus fixing the issue.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX

### Test Plan:

By using the following config in the example model:
```
{{ config(
    materialized='table',
    tblproperties={'write.object-storage.enabled':'true'},
    partition_by=['id'],
    file_format='iceberg'
) }}

```
It produced:
```
1: jdbc:hive2://localhost:10000> show tblproperties first_dbt_model_1;
+-------------------------------+----------------------+
|              key              |        value         |
+-------------------------------+----------------------+
| current-snapshot-id           | 6381028787934334351  |
| format                        | iceberg/parquet      |
| format-version                | 1                    |
| write.object-storage.enabled  | true                 |
+-------------------------------+----------------------+
4 rows selected (0.86 seconds)
1: jdbc:hive2://localhost:10000>
```