### PR TITLE
ADAP-894: Support test results as views

### DIFF
--- a/.changes/unreleased/Features-20230921-180958.yaml
+++ b/.changes/unreleased/Features-20230921-180958.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support test results as views
+time: 2023-09-21T18:09:58.174136-04:00
+custom:
+  Author: mikealfare
+  Issue: "6914"

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ dev: ## Installs adapter in develop mode along with development dependencies
 dev-uninstall: ## Uninstalls all packages while maintaining the virtual environment
                ## Useful when updating versions, or if you accidentally installed into the system interpreter
 	pip freeze | grep -v "^-e" | cut -d "@" -f1 | xargs pip uninstall -y
+	pip uninstall -y dbt-spark
 
 .PHONY: mypy
 mypy: ## Runs mypy against staged changes for static type checking.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git@feature/materialized-tests/adap-850#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@feature/materialized-tests/adap-850#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor

--- a/tests/functional/adapter/test_persist_test_results.py
+++ b/tests/functional/adapter/test_persist_test_results.py
@@ -1,0 +1,5 @@
+from dbt.tests.adapter.persist_test_results.basic import PersistTestResults
+
+
+class TestPersistTestResults(PersistTestResults):
+    pass


### PR DESCRIPTION
resolves dbt-labs/dbt-core#6914
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

This will support persisting tests results as views. See the attached issue for more information.

### Solution

Users can use `strategy="view"` in the `config` block in their dbt tests to create the test results as a view. This allows the results to update along with underlying data, e.g. when the underlying data is in a dynamic table.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
