### PR TITLE
Switch ceil to floor

### DIFF
--- a/dbt/include/spark/macros/utils/datediff.sql
+++ b/dbt/include/spark/macros/utils/datediff.sql
@@ -73,12 +73,12 @@
         {%- endset -%}
 
         case when {{first_date}} < {{second_date}}
-            then ceil((
+            then floor((
                 {# make sure the timestamps are real, otherwise raise an error asap #}
                 {{ assert_not_null('to_unix_timestamp', assert_not_null('to_timestamp', second_date)) }}
                 - {{ assert_not_null('to_unix_timestamp', assert_not_null('to_timestamp', first_date)) }}
             ) / {{divisor}})
-            else floor((
+            else ceil((
                 {{ assert_not_null('to_unix_timestamp', assert_not_null('to_timestamp', second_date)) }}
                 - {{ assert_not_null('to_unix_timestamp', assert_not_null('to_timestamp', first_date)) }}
             ) / {{divisor}})

--- a/dbt/include/spark/macros/utils/datediff.sql
+++ b/dbt/include/spark/macros/utils/datediff.sql
@@ -105,3 +105,4 @@
     {%- endif -%}
 
 {% endmacro %}
+


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

When calculating datediff in "hour"s with spark, we get a result that is larger by 1 relatively to all other warehouses when using datediff.

### Solution

Swapping CEIL and FLOOR as in all other cases

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
