### PR TITLE
Add support for Spark Connect (SQL models)

### DIFF
--- a/.changes/unreleased/Features-20231004-191452.yaml
+++ b/.changes/unreleased/Features-20231004-191452.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add support for Spark Connect
+time: 2023-10-04T19:14:52.858895+03:00
+custom:
+  Author: vakarisbk
+  Issue: "899"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,6 +57,7 @@ jobs:
           - "databricks_sql_endpoint"
           - "databricks_cluster"
           - "databricks_http_cluster"
+          - "spark_connect"
 
     env:
       DBT_INVOCATION_ENV: github-actions

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
 git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
+git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,8 @@ sqlparams>=3.0.0
 thrift>=0.13.0
 sqlparse>=0.4.2 # not directly required, pinned by Snyk to avoid a vulnerability
 
+#spark-connect
+pyspark[connect]>=3.5.0,<4
+
 types-PyYAML
 types-python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,16 @@ pyhive_extras = [
     "thrift>=0.11.0,<0.17.0",
 ]
 session_extras = ["pyspark>=3.0.0,<4.0.0"]
-all_extras = odbc_extras + pyhive_extras + session_extras
+connect_extras = [
+    "pyspark==3.5.0",
+    "pandas>=1.05",
+    "pyarrow>=4.0.0",
+    "numpy>=1.15",
+    "grpcio>=1.46,<1.57",
+    "grpcio-status>=1.46,<1.57",
+    "googleapis-common-protos==1.56.4",
+]
+all_extras = odbc_extras + pyhive_extras + session_extras + connect_extras
 
 setup(
     name=package_name,
@@ -71,6 +80,7 @@ setup(
         "ODBC": odbc_extras,
         "PyHive": pyhive_extras,
         "session": session_extras,
+        "connect": connect_extras,
         "all": all_extras,
     },
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -50,13 +50,7 @@ pyhive_extras = [
 ]
 session_extras = ["pyspark>=3.0.0,<4.0.0"]
 connect_extras = [
-    "pyspark==3.5.0",
-    "pandas>=1.05",
-    "pyarrow>=4.0.0",
-    "numpy>=1.15",
-    "grpcio>=1.46,<1.57",
-    "grpcio-status>=1.46,<1.57",
-    "googleapis-common-protos==1.56.4",
+    "pyspark[connect]>=3.5.0<4.0.0",
 ]
 all_extras = odbc_extras + pyhive_extras + session_extras + connect_extras
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,8 @@ def dbt_profile_target(request):
         target = databricks_http_cluster_target()
     elif profile_type == "spark_session":
         target = spark_session_target()
+    elif profile_type == "spark_connect":
+        target = spark_connect_target()
     else:
         raise ValueError(f"Invalid profile type '{profile_type}'")
     return target
@@ -95,11 +97,11 @@ def databricks_http_cluster_target():
 
 
 def spark_session_target():
-    return {
-        "type": "spark",
-        "host": "localhost",
-        "method": "session",
-    }
+    return {"type": "spark", "host": "localhost", "method": "session"}
+
+
+def spark_connect_target():
+    return {"type": "spark", "host": "localhost", "port": 15002, "method": "connect"}
 
 
 @pytest.fixture(autouse=True)

--- a/tests/functional/adapter/dbt_clone/test_dbt_clone.py
+++ b/tests/functional/adapter/dbt_clone/test_dbt_clone.py
@@ -14,7 +14,7 @@ from tests.functional.adapter.dbt_clone.fixtures import (
 )
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_connect")
 class TestSparkBigqueryClonePossible(BaseClonePossible):
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/functional/adapter/incremental/test_incremental_merge_exclude_columns.py
+++ b/tests/functional/adapter/incremental/test_incremental_merge_exclude_columns.py
@@ -5,7 +5,7 @@ from dbt.tests.adapter.incremental.test_incremental_merge_exclude_columns import
 )
 
 
-@pytest.mark.skip_profile("spark_session", "apache_spark")
+@pytest.mark.skip_profile("spark_session", "apache_spark", "spark_connect")
 class TestMergeExcludeColumns(BaseMergeExcludeColumns):
     @pytest.fixture(scope="class")
     def project_config_update(self):

--- a/tests/functional/adapter/incremental/test_incremental_on_schema_change.py
+++ b/tests/functional/adapter/incremental/test_incremental_on_schema_change.py
@@ -32,7 +32,7 @@ class TestAppendOnSchemaChange(IncrementalOnSchemaChangeIgnoreFail):
         }
 
 
-@pytest.mark.skip_profile("databricks_sql_endpoint", "spark_session")
+@pytest.mark.skip_profile("databricks_sql_endpoint", "spark_session", "spark_connect")
 class TestInsertOverwriteOnSchemaChange(IncrementalOnSchemaChangeIgnoreFail):
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -45,7 +45,7 @@ class TestInsertOverwriteOnSchemaChange(IncrementalOnSchemaChangeIgnoreFail):
         }
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_connect")
 class TestDeltaOnSchemaChange(BaseIncrementalOnSchemaChangeSetup):
     @pytest.fixture(scope="class")
     def project_config_update(self):

--- a/tests/functional/adapter/incremental/test_incremental_predicates.py
+++ b/tests/functional/adapter/incremental/test_incremental_predicates.py
@@ -27,7 +27,7 @@ select cast(3 as bigint) as id, 'anyway' as msg, 'purple' as color
 """
 
 
-@pytest.mark.skip_profile("spark_session", "apache_spark")
+@pytest.mark.skip_profile("spark_session", "apache_spark", "spark_connect")
 class TestIncrementalPredicatesMergeSpark(BaseIncrementalPredicates):
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -46,7 +46,7 @@ class TestIncrementalPredicatesMergeSpark(BaseIncrementalPredicates):
         }
 
 
-@pytest.mark.skip_profile("spark_session", "apache_spark")
+@pytest.mark.skip_profile("spark_session", "apache_spark", "spark_connect")
 class TestPredicatesMergeSpark(BaseIncrementalPredicates):
     @pytest.fixture(scope="class")
     def project_config_update(self):

--- a/tests/functional/adapter/incremental/test_incremental_unique_id.py
+++ b/tests/functional/adapter/incremental/test_incremental_unique_id.py
@@ -2,7 +2,7 @@ import pytest
 from dbt.tests.adapter.incremental.test_incremental_unique_id import BaseIncrementalUniqueKey
 
 
-@pytest.mark.skip_profile("spark_session", "apache_spark")
+@pytest.mark.skip_profile("spark_session", "apache_spark", "spark_connect")
 class TestUniqueKeySpark(BaseIncrementalUniqueKey):
     @pytest.fixture(scope="class")
     def project_config_update(self):

--- a/tests/functional/adapter/incremental_strategies/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental_strategies/test_incremental_strategies.py
@@ -103,7 +103,11 @@ class TestDeltaStrategies(BaseIncrementalStrategies):
         check_relations_equal(project.adapter, ["merge_update_columns", "expected_partial_upsert"])
 
     @pytest.mark.skip_profile(
-        "apache_spark", "databricks_http_cluster", "databricks_sql_endpoint", "spark_session"
+        "apache_spark",
+        "databricks_http_cluster",
+        "databricks_sql_endpoint",
+        "spark_session",
+        "spark_connect",
     )
     def test_delta_strategies(self, project):
         self.run_and_test(project)

--- a/tests/functional/adapter/persist_docs/test_persist_docs.py
+++ b/tests/functional/adapter/persist_docs/test_persist_docs.py
@@ -15,7 +15,7 @@ from fixtures import (
 )
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_connect")
 class TestPersistDocsDeltaTable:
     @pytest.fixture(scope="class")
     def models(self):
@@ -78,7 +78,7 @@ class TestPersistDocsDeltaTable:
                     assert result[2].startswith("Some stuff here and then a call to")
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_connect")
 class TestPersistDocsDeltaView:
     @pytest.fixture(scope="class")
     def models(self):
@@ -120,7 +120,7 @@ class TestPersistDocsDeltaView:
                 assert result[2] is None
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_connect")
 class TestPersistDocsMissingColumn:
     @pytest.fixture(scope="class")
     def project_config_update(self):

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -50,7 +50,7 @@ class TestGenericTestsSpark(BaseGenericTests):
 
 # These tests were not enabled in the dbtspec files, so skipping here.
 # Error encountered was: Error running query: java.lang.ClassNotFoundException: delta.DefaultSource
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_connect")
 class TestSnapshotCheckColsSpark(BaseSnapshotCheckCols):
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -66,7 +66,7 @@ class TestSnapshotCheckColsSpark(BaseSnapshotCheckCols):
 
 # These tests were not enabled in the dbtspec files, so skipping here.
 # Error encountered was: Error running query: java.lang.ClassNotFoundException: delta.DefaultSource
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_connect")
 class TestSnapshotTimestampSpark(BaseSnapshotTimestamp):
     @pytest.fixture(scope="class")
     def project_config_update(self):

--- a/tests/functional/adapter/test_constraints.py
+++ b/tests/functional/adapter/test_constraints.py
@@ -147,7 +147,9 @@ class DatabricksHTTPSetup:
         ]
 
 
-@pytest.mark.skip_profile("spark_session", "apache_spark", "databricks_http_cluster")
+@pytest.mark.skip_profile(
+    "spark_session", "apache_spark", "databricks_http_cluster", "spark_connect"
+)
 class TestSparkTableConstraintsColumnsEqualPyodbc(PyodbcSetup, BaseTableConstraintsColumnsEqual):
     @pytest.fixture(scope="class")
     def models(self):
@@ -158,7 +160,9 @@ class TestSparkTableConstraintsColumnsEqualPyodbc(PyodbcSetup, BaseTableConstrai
         }
 
 
-@pytest.mark.skip_profile("spark_session", "apache_spark", "databricks_http_cluster")
+@pytest.mark.skip_profile(
+    "spark_session", "apache_spark", "databricks_http_cluster", "spark_connect"
+)
 class TestSparkViewConstraintsColumnsEqualPyodbc(PyodbcSetup, BaseViewConstraintsColumnsEqual):
     @pytest.fixture(scope="class")
     def models(self):
@@ -169,7 +173,9 @@ class TestSparkViewConstraintsColumnsEqualPyodbc(PyodbcSetup, BaseViewConstraint
         }
 
 
-@pytest.mark.skip_profile("spark_session", "apache_spark", "databricks_http_cluster")
+@pytest.mark.skip_profile(
+    "spark_session", "apache_spark", "databricks_http_cluster", "spark_connect"
+)
 class TestSparkIncrementalConstraintsColumnsEqualPyodbc(
     PyodbcSetup, BaseIncrementalConstraintsColumnsEqual
 ):
@@ -183,7 +189,11 @@ class TestSparkIncrementalConstraintsColumnsEqualPyodbc(
 
 
 @pytest.mark.skip_profile(
-    "spark_session", "apache_spark", "databricks_sql_endpoint", "databricks_cluster"
+    "spark_session",
+    "apache_spark",
+    "databricks_sql_endpoint",
+    "databricks_cluster",
+    "spark_connect",
 )
 class TestSparkTableConstraintsColumnsEqualDatabricksHTTP(
     DatabricksHTTPSetup, BaseTableConstraintsColumnsEqual
@@ -198,7 +208,11 @@ class TestSparkTableConstraintsColumnsEqualDatabricksHTTP(
 
 
 @pytest.mark.skip_profile(
-    "spark_session", "apache_spark", "databricks_sql_endpoint", "databricks_cluster"
+    "spark_session",
+    "apache_spark",
+    "databricks_sql_endpoint",
+    "databricks_cluster",
+    "spark_connect",
 )
 class TestSparkViewConstraintsColumnsEqualDatabricksHTTP(
     DatabricksHTTPSetup, BaseViewConstraintsColumnsEqual
@@ -213,7 +227,11 @@ class TestSparkViewConstraintsColumnsEqualDatabricksHTTP(
 
 
 @pytest.mark.skip_profile(
-    "spark_session", "apache_spark", "databricks_sql_endpoint", "databricks_cluster"
+    "spark_session",
+    "apache_spark",
+    "databricks_sql_endpoint",
+    "databricks_cluster",
+    "spark_connect",
 )
 class TestSparkIncrementalConstraintsColumnsEqualDatabricksHTTP(
     DatabricksHTTPSetup, BaseIncrementalConstraintsColumnsEqual
@@ -241,7 +259,7 @@ class BaseSparkConstraintsDdlEnforcementSetup:
         return _expected_sql_spark
 
 
-@pytest.mark.skip_profile("spark_session", "apache_spark")
+@pytest.mark.skip_profile("spark_session", "apache_spark", "spark_connect")
 class TestSparkTableConstraintsDdlEnforcement(
     BaseSparkConstraintsDdlEnforcementSetup, BaseConstraintsRuntimeDdlEnforcement
 ):
@@ -254,7 +272,7 @@ class TestSparkTableConstraintsDdlEnforcement(
         }
 
 
-@pytest.mark.skip_profile("spark_session", "apache_spark")
+@pytest.mark.skip_profile("spark_session", "apache_spark", "spark_connect")
 class TestSparkIncrementalConstraintsDdlEnforcement(
     BaseSparkConstraintsDdlEnforcementSetup, BaseIncrementalConstraintsRuntimeDdlEnforcement
 ):
@@ -267,7 +285,9 @@ class TestSparkIncrementalConstraintsDdlEnforcement(
         }
 
 
-@pytest.mark.skip_profile("spark_session", "apache_spark", "databricks_http_cluster")
+@pytest.mark.skip_profile(
+    "spark_session", "apache_spark", "databricks_http_cluster", "spark_connect"
+)
 class TestSparkConstraintQuotedColumn(PyodbcSetup, BaseConstraintQuotedColumn):
     @pytest.fixture(scope="class")
     def models(self):
@@ -326,7 +346,7 @@ class BaseSparkConstraintsRollbackSetup:
         assert any(msg in error_message for msg in expected_error_messages)
 
 
-@pytest.mark.skip_profile("spark_session", "apache_spark")
+@pytest.mark.skip_profile("spark_session", "apache_spark", "spark_connect")
 class TestSparkTableConstraintsRollback(
     BaseSparkConstraintsRollbackSetup, BaseConstraintsRollback
 ):
@@ -345,7 +365,7 @@ class TestSparkTableConstraintsRollback(
         return "red"
 
 
-@pytest.mark.skip_profile("spark_session", "apache_spark")
+@pytest.mark.skip_profile("spark_session", "apache_spark", "spark_connect")
 class TestSparkIncrementalConstraintsRollback(
     BaseSparkConstraintsRollbackSetup, BaseIncrementalConstraintsRollback
 ):
@@ -362,7 +382,7 @@ class TestSparkIncrementalConstraintsRollback(
 # TODO: Like the tests above, this does test that model-level constraints don't
 # result in errors, but it does not verify that they are actually present in
 # Spark and that the ALTER TABLE statement actually ran.
-@pytest.mark.skip_profile("spark_session", "apache_spark")
+@pytest.mark.skip_profile("spark_session", "apache_spark", "spark_connect")
 class TestSparkModelConstraintsRuntimeEnforcement(BaseModelConstraintsRuntimeEnforcement):
     @pytest.fixture(scope="class")
     def project_config_update(self):

--- a/tests/functional/adapter/test_grants.py
+++ b/tests/functional/adapter/test_grants.py
@@ -6,7 +6,7 @@ from dbt.tests.adapter.grants.test_seed_grants import BaseSeedGrants
 from dbt.tests.adapter.grants.test_snapshot_grants import BaseSnapshotGrants
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_connect")
 class TestModelGrantsSpark(BaseModelGrants):
     def privilege_grantee_name_overrides(self):
         # insert --> modify
@@ -18,7 +18,7 @@ class TestModelGrantsSpark(BaseModelGrants):
         }
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_connect")
 class TestIncrementalGrantsSpark(BaseIncrementalGrants):
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -30,7 +30,7 @@ class TestIncrementalGrantsSpark(BaseIncrementalGrants):
         }
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_connect")
 class TestSeedGrantsSpark(BaseSeedGrants):
     # seeds in dbt-spark are currently "full refreshed," in such a way that
     # the grants are not carried over
@@ -39,7 +39,7 @@ class TestSeedGrantsSpark(BaseSeedGrants):
         return False
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_connect")
 class TestSnapshotGrantsSpark(BaseSnapshotGrants):
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -51,7 +51,7 @@ class TestSnapshotGrantsSpark(BaseSnapshotGrants):
         }
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_connect")
 class TestInvalidGrantsSpark(BaseInvalidGrants):
     def grantee_does_not_exist_error(self):
         return "RESOURCE_DOES_NOT_EXIST"

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -8,17 +8,23 @@ from dbt.tests.adapter.python_model.test_python_model import (
 from dbt.tests.adapter.python_model.test_spark import BasePySparkTests
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session", "databricks_sql_endpoint")
+@pytest.mark.skip_profile(
+    "apache_spark", "spark_session", "databricks_sql_endpoint", "spark_connect"
+)
 class TestPythonModelSpark(BasePythonModelTests):
     pass
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session", "databricks_sql_endpoint")
+@pytest.mark.skip_profile(
+    "apache_spark", "spark_session", "databricks_sql_endpoint", "spark_connect"
+)
 class TestPySpark(BasePySparkTests):
     pass
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session", "databricks_sql_endpoint")
+@pytest.mark.skip_profile(
+    "apache_spark", "spark_session", "databricks_sql_endpoint", "spark_connect"
+)
 class TestPythonIncrementalModelSpark(BasePythonIncrementalTests):
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -63,7 +69,9 @@ def model(dbt, spark):
 """
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session", "databricks_sql_endpoint")
+@pytest.mark.skip_profile(
+    "apache_spark", "spark_session", "databricks_sql_endpoint", "spark_connect"
+)
 class TestChangingSchemaSpark:
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/functional/adapter/test_store_test_failures.py
+++ b/tests/functional/adapter/test_store_test_failures.py
@@ -34,7 +34,7 @@ class TestSparkStoreTestFailures(StoreTestFailuresBase):
         self.run_tests_store_failures_and_assert(project)
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_connect")
 class TestSparkStoreTestFailuresWithDelta(StoreTestFailuresBase):
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -82,7 +82,8 @@ class TestStoreTestFailuresAsProjectLevelView(basic.StoreTestFailuresAsProjectLe
     pass
 
 
-@pytest.mark.skip_profile("spark_session")
+# spark connect fails because of issue [ADAP-931]
+@pytest.mark.skip_profile("spark_session", "spark_connect")
 class TestStoreTestFailuresAsGeneric(basic.StoreTestFailuresAsGeneric):
     pass
 

--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -62,6 +62,7 @@ class TestArrayConstruct(BaseArrayConstruct):
     pass
 
 
+@pytest.mark.skip_profile("spark_connect")
 class TestBoolOr(BaseBoolOr):
     pass
 
@@ -80,16 +81,18 @@ class TestCurrentTimestamp(BaseCurrentTimestampNaive):
     pass
 
 
+@pytest.mark.skip_profile("spark_connect")
 class TestDateAdd(BaseDateAdd):
     pass
 
 
 # this generates too much SQL to run successfully in our testing environments :(
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_connect")
 class TestDateDiff(BaseDateDiff):
     pass
 
 
+@pytest.mark.skip_profile("spark_connect")
 class TestDateTrunc(BaseDateTrunc):
     pass
 
@@ -139,12 +142,12 @@ class TestPosition(BasePosition):
     pass
 
 
-@pytest.mark.skip_profile("spark_session")
+@pytest.mark.skip_profile("spark_session", "spark_connect")
 class TestReplace(BaseReplace):
     pass
 
 
-@pytest.mark.skip_profile("spark_session")
+@pytest.mark.skip_profile("spark_session", "spark_connect")
 class TestRight(BaseRight):
     pass
 


### PR DESCRIPTION
partially resolves dbt-labs/dbt-adapters#493
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

dbt-spark has limited options for open-source Spark integrations. Currently, the only available method to run dbt with open-source Spark in production is through a Thrift connection. However, a Thrift connection isn't suitable for all use cases. For instance, [it doesn't support thrift over HTTP](https://github.com/dropbox/PyHive/pull/325). Also, the PyHive project, that dbt thrift relies on, is unsupported (at least according to their GitHub page).

### Solution
Propose introducing support for [Spark Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html) (for SQL models only).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX

### How to test locally?

1. Follow the instructions in the Spark documentation to download Spark distribution. https://spark.apache.org/docs/latest/spark-connect-overview.html
2. Start spark connect server with Hive metastore enabled ```./start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:3.5.0 --conf spark.sql.catalogImplementation=hive```
3. Add the Spark Connect configuration to your profiles.yml:
```
spark_connect:
  outputs:
    dev:
      host: localhost
      method: connect
      port: 15002
      schema: default
      type: spark
  target: dev
```

### Known issues: dbt-labs/dbt-adapters#487

