### PR TITLE
insert overwrite instead of insert into for new seed runs

### DIFF
--- a/.changes/unreleased/Fixes-20231013-120628.yaml
+++ b/.changes/unreleased/Fixes-20231013-120628.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: overwrite existing rows from existin seed tables. the current seed command in
+  dbt-spark appends to existing seeded tables instead overwriting.
+time: 2023-10-13T12:06:28.078483-06:00
+custom:
+  Author: mv1742
+  Issue: "112"

--- a/.changes/unreleased/Fixes-20231013-120628.yaml
+++ b/.changes/unreleased/Fixes-20231013-120628.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: overwrite existing rows from existin seed tables. the current seed command in
+body: Overwrite existing rows on existing seed tables. For unmanaged databases (no location specified), the current seed command in
   dbt-spark appends to existing seeded tables instead overwriting.
 time: 2023-10-13T12:06:28.078483-06:00
 custom:

--- a/dbt/include/spark/macros/materializations/seed.sql
+++ b/dbt/include/spark/macros/materializations/seed.sql
@@ -27,7 +27,7 @@
       {% endfor %}
 
       {% set sql %}
-          insert into {{ this.render() }} values
+          insert {% if loop.index0 == 0 -%} overwrite {% else -%} into {% endif -%} {{ this.render() }} values
           {% for row in chunk -%}
               ({%- for col_name in agate_table.column_names -%}
                   {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-spark/issues/112

Description

dbt seed command fixed with expected behavior from [dbt global project](https://github.com/fishtown-analytics/dbt/blob/develop/core/dbt/include/global_project/macros/materializations/seed/seed.sql) to [truncate table](https://spark.apache.org/docs/3.0.0-preview/sql-ref-syntax-ddl-truncate-table.html) in order remove all rows from the existing seed tables and replace values. As explained in https://github.com/fishtown-analytics/dbt-spark/issues/112, the current seed command in dbt-spark appends to existing seeded tables instead overwriting when the database is 'unmanaged' (no location specified from `create schema`)

Checklist

- [ ]  I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ]  I have run this code in development and it appears to resolve the stated issue
- [ ]  This PR includes tests, or tests are not required/relevant for this PR
- [ ]  I have updated the changelog using change and added information about my change to the "dbt next" section.