### PR TITLE
Mv1742 load csv table seed

### DIFF
--- a/.changes/unreleased/Fixes-20231013-120032.yaml
+++ b/.changes/unreleased/Fixes-20231013-120032.yaml
@@ -1,7 +1,0 @@
-kind: Fixes
-body: '- dbt seed now removes all rows from the existing seed tables and replace values.
-  As explained in [issue 112](https://github.com/fishtown-analytics/dbt-spar'
-time: 2023-10-13T12:00:32.866957-06:00
-custom:
-  Author: mv1742
-  Issue: "112"

--- a/.changes/unreleased/Fixes-20231013-120032.yaml
+++ b/.changes/unreleased/Fixes-20231013-120032.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: '- dbt seed now removes all rows from the existing seed tables and replace values.
+  As explained in [issue 112](https://github.com/fishtown-analytics/dbt-spar'
+time: 2023-10-13T12:00:32.866957-06:00
+custom:
+  Author: mv1742
+  Issue: "112"

--- a/.changes/unreleased/Fixes-20231013-120628.yaml
+++ b/.changes/unreleased/Fixes-20231013-120628.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Overwrite existing rows on existing seed tables. For unmanaged databases (no location specified), the current seed command in
+  dbt-spark appends to existing seeded tables instead overwriting.
+time: 2023-10-13T12:06:28.078483-06:00
+custom:
+  Author: mv1742
+  Issue: "112"

--- a/dbt/include/spark/macros/materializations/seed.sql
+++ b/dbt/include/spark/macros/materializations/seed.sql
@@ -27,7 +27,7 @@
       {% endfor %}
 
       {% set sql %}
-          insert into {{ this.render() }} values
+          insert {% if loop.index0 == 0 -%} overwrite {% else -%} into {% endif -%} {{ this.render() }} values
           {% for row in chunk -%}
               ({%- for col_name in agate_table.column_names -%}
                   {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}


### PR DESCRIPTION
resolves #
resolves https://github.com/dbt-labs/dbt-spark/issues/112

Description

### Problem

The current seed command in dbt-spark appends to existing seeded tables instead overwriting when the database is 'unmanaged' (no location specified from create schema)

### Solution


overwrite all rows from the existing seed tables and replace values.

Checklist

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
