### PR TITLE
Initialize Adapter Integration Tests workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,20 @@
+name: Adapter Integration Tests
+
+on:
+  workflow_dispatch:
+
+# explicitly turn off permissions for `GITHUB_TOKEN`
+permissions: read-all
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-metadata:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository (non-PR)
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false


### PR DESCRIPTION
### Problem

We cannot test the new Adapter Integration Tests workflow on a PR.

### Solution

Create a very stripped down version of the workflow to merge into `main` so that we can manually dispatch the workflow on the PR branch.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
