### PR TITLE
Support new agate Integer type and test with empty seed

### DIFF
--- a/.changes/unreleased/Fixes-20231107-134141.yaml
+++ b/.changes/unreleased/Fixes-20231107-134141.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Support new agate Integer type and empty seed test
+time: 2023-11-07T13:41:41.033441-05:00
+custom:
+  Author: gshank
+  Issue: "935"

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -121,6 +121,10 @@ class SparkAdapter(SQLAdapter):
         return "double" if decimals else "bigint"
 
     @classmethod
+    def convert_integer_type(cls, agate_table: agate.Table, col_idx: int) -> str:
+        return "bigint"
+
+    @classmethod
     def convert_date_type(cls, agate_table: agate.Table, col_idx: int) -> str:
         return "date"
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git@8895-agate_integer_conversion#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git@8895-agate_integer_conversion#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git@8895-agate_integer_conversion#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@8895-agate_integer_conversion#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor

--- a/tests/functional/adapter/test_simple_seed.py
+++ b/tests/functional/adapter/test_simple_seed.py
@@ -1,0 +1,5 @@
+from dbt.tests.adapter.simple_seed.test_seed import BaseTestEmptySeed
+
+
+class TestBigQueryEmptySeed(BaseTestEmptySeed):
+    pass


### PR DESCRIPTION
resolves #935

### Problem

dbt Core added support for an agate integer type to support the show command. Empty seeds were failing due to lack of support in the "convert_" methods in impl.py, so a regression bug case fixed that.

### Solution

Add a "convert_integer_type" method and include test of empty seed creation.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
