### PR TITLE
Remove unused `invalid_insert_overwrite_delta_msg` variable

### DIFF
--- a/.changes/unreleased/Under the Hood-20231214-134728.yaml
+++ b/.changes/unreleased/Under the Hood-20231214-134728.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove unused `invalid_insert_overwrite_delta_msg` message
+time: 2023-12-14T13:47:28.444107-07:00
+custom:
+  Author: dbeatty10
+  Issue: "962"

--- a/dbt/include/spark/macros/materializations/incremental/validate.sql
+++ b/dbt/include/spark/macros/materializations/incremental/validate.sql
@@ -29,17 +29,12 @@
     You can only choose this strategy when file_format is set to 'delta' or 'iceberg' or 'hudi'
   {%- endset %}
 
-  {% set invalid_insert_overwrite_delta_msg -%}
-    Invalid incremental strategy provided: {{ raw_strategy }}
-    You cannot use this strategy when file_format is set to 'delta' or 'iceberg'
-    Use the 'append' or 'merge' strategy instead
-  {%- endset %}
-
   {% set invalid_insert_overwrite_endpoint_msg -%}
     Invalid incremental strategy provided: {{ raw_strategy }}
     You cannot use this strategy when connecting via endpoint
     Use the 'append' or 'merge' strategy instead
   {%- endset %}
+
   {% if raw_strategy not in ['append', 'merge', 'insert_overwrite'] %}
     {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
   {%-else %}


### PR DESCRIPTION
resolves #962

### Problem

While researching https://github.com/dbt-labs/docs.getdbt.com/issues/4639, it looks like [this code](https://github.com/dbt-labs/dbt-spark/blob/ffc24ba30aa87e38e42ced897ccb19961425ad81/dbt/include/spark/macros/materializations/incremental/validate.sql#L32-L36) is unused since https://github.com/dbt-labs/dbt-spark/pull/700.

### Solution

Searching both dbt-spark and dbt-databricks didn't yield any other references to `invalid_insert_overwrite_delta_msg`:
- https://github.com/search?q=repo%3Adbt-labs%2Fdbt-spark%20invalid_insert_overwrite_delta_msg&type=code
- https://github.com/search?q=repo%3Adatabricks%2Fdbt-databricks%20invalid_insert_overwrite_delta_msg&type=code

So it appears safe to remove it altogether.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] Tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)