### PR TITLE
 Implement relation filtering on get_catalog macro

### DIFF
--- a/.changes/unreleased/Features-20231215-191154.yaml
+++ b/.changes/unreleased/Features-20231215-191154.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support limiting get_catalog by object name
+time: 2023-12-15T19:11:54.536441-05:00
+custom:
+  Author: mikealfare
+  Issue: "900"

--- a/dbt/adapters/spark/cache.py
+++ b/dbt/adapters/spark/cache.py
@@ -20,7 +20,7 @@ class SparkRelationsCache(RelationsCache):
                     {
                         lowercase(relation.database) == lowercase(relation_stub.database),
                         lowercase(relation.schema) == lowercase(relation_stub.schema),
-                        lowercase(relation.schema) == lowercase(relation_stub.identifier),
+                        lowercase(relation.identifier) == lowercase(relation_stub.identifier),
                     }
                 )
             ]

--- a/dbt/adapters/spark/cache.py
+++ b/dbt/adapters/spark/cache.py
@@ -1,0 +1,29 @@
+from dbt.adapters.base import BaseRelation
+from dbt.adapters.cache import RelationsCache
+from dbt.exceptions import MissingRelationError
+from dbt.utils import lowercase
+
+
+class SparkRelationsCache(RelationsCache):
+    def get_relation_from_stub(self, relation_stub: BaseRelation) -> BaseRelation:
+        """
+        Case-insensitively yield all relations matching the given schema.
+
+        :param BaseRelation relation_stub: The relation to look for
+        :return BaseRelation: The cached version of the relation
+        """
+        with self.lock:
+            results = [
+                relation.inner
+                for relation in self.relations.values()
+                if all(
+                    {
+                        lowercase(relation.database) == lowercase(relation_stub.database),
+                        lowercase(relation.schema) == lowercase(relation_stub.schema),
+                        lowercase(relation.schema) == lowercase(relation_stub.identifier),
+                    }
+                )
+            ]
+        if len(results) == 0:
+            raise MissingRelationError(relation_stub)
+        return results[0]

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -415,6 +415,7 @@ class SparkAdapter(SQLAdapter):
             raise dbt.exceptions.CompilationError(
                 f"Expected only one schema in spark _get_one_catalog, found " f"{schemas}"
             )
+
         database = information_schema.database
         schema = list(schemas)[0]
         relations = self.list_relations(database, schema)

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -385,25 +385,7 @@ class SparkAdapter(SQLAdapter):
     def get_catalog_by_relations(
         self, manifest: Manifest, relations: Set[BaseRelation]
     ) -> Tuple[agate.Table, List[Exception]]:
-        schema_map = self._get_catalog_schemas(manifest)
-
-        with executor(self.config) as tpe:
-            futures: List[Future[agate.Table]] = []
-            for info, schemas in schema_map.items():
-                for schema in schemas:
-                    if relations_in_schema := [r for r in relations if r.schema == schema]:
-                        futures.append(
-                            tpe.submit_connected(
-                                self,
-                                schema,
-                                self._get_one_catalog_by_relations,
-                                info,
-                                relations_in_schema,
-                                manifest,
-                            )
-                        )
-            catalogs, exceptions = catch_as_completed(futures)
-        return catalogs, exceptions
+        return self.get_catalog(manifest)
 
     def _get_one_catalog(
         self,

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -103,7 +103,7 @@ class SparkAdapter(SQLAdapter):
     }
 
     _capabilities = CapabilityDict(
-        {Capability.SchemaMetadataByRelations: CapabilitySupport(support=Support.Full)}
+        {Capability.SchemaMetadataByRelations: CapabilitySupport(support=Support.NotImplemented)}
     )
 
     Relation: TypeAlias = SparkRelation
@@ -386,9 +386,9 @@ class SparkAdapter(SQLAdapter):
         self, manifest: Manifest, relations: Set[BaseRelation]
     ) -> Tuple[agate.Table, List[Exception]]:
         relations_by_info_schema = self._get_catalog_relations_by_info_schema(relations)
-        futures: List[Future[agate.Table]] = []
 
         with executor(self.config) as tpe:
+            futures: List[Future[agate.Table]] = []
             for info_schema, relations_in_info_schema in relations_by_info_schema.items():
                 fut = tpe.submit_connected(
                     self,
@@ -399,8 +399,7 @@ class SparkAdapter(SQLAdapter):
                     manifest,
                 )
                 futures.append(fut)
-
-        catalogs, exceptions = catch_as_completed(futures)
+            catalogs, exceptions = catch_as_completed(futures)
         return catalogs, exceptions
 
     def _get_one_catalog(

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -363,10 +363,10 @@ class SparkAdapter(SQLAdapter):
     def get_catalog(
         self, manifest: Manifest, selected_nodes: Optional[Set] = None
     ) -> Tuple[agate.Table, List[Exception]]:
-        schema_map = self._get_catalog_schemas(manifest)  # info_schema: [relation_schema]
+        schema_map = self._get_catalog_schemas(manifest)
         if len(schema_map) > 1:
             raise dbt.exceptions.CompilationError(
-                f"Expected only one database in get_catalog, found {list(schema_map)}"
+                f"Expected only one database in get_catalog, found " f"{list(schema_map)}"
             )
 
         with executor(self.config) as tpe:
@@ -413,7 +413,7 @@ class SparkAdapter(SQLAdapter):
     ) -> agate.Table:
         if len(schemas) != 1:
             raise dbt.exceptions.CompilationError(
-                f"Expected only one schema in spark _get_one_catalog, found {schemas}"
+                f"Expected only one schema in spark _get_one_catalog, found " f"{schemas}"
             )
 
         relations = self.list_relations(information_schema.database, schemas.pop())
@@ -433,7 +433,7 @@ class SparkAdapter(SQLAdapter):
     def _get_relation_metadata_at_column_level(self, relations: List[BaseRelation]) -> agate.Table:
         columns: List[Dict[str, Any]] = []
         for relation in relations:
-            logger.debug(f"Getting table schema for relation {relation}")
+            logger.debug("Getting table schema for relation {}", str(relation))
             columns.extend(self._get_columns_for_catalog(relation))
         return agate.Table.from_object(columns, column_types=DEFAULT_TYPE_TESTER)
 

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -396,7 +396,7 @@ class SparkAdapter(SQLAdapter):
                     [
                         tpe.submit_connected(
                             self,
-                            info_schema.identifier,
+                            "list_schemas",
                             self._get_one_catalog_by_relations,
                             info_schema,
                             relations,

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -3,7 +3,7 @@ from concurrent.futures import Future
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Union, Type, Tuple, Callable, Set
 
-from dbt.adapters.base.relation import InformationSchema, SchemaSearchMap
+from dbt.adapters.base.relation import InformationSchema
 from dbt.adapters.capability import CapabilityDict, CapabilitySupport, Support, Capability
 from dbt.contracts.graph.manifest import Manifest
 
@@ -384,26 +384,11 @@ class SparkAdapter(SQLAdapter):
     def get_catalog_by_relations(
         self, manifest: Manifest, relations: Set[BaseRelation]
     ) -> Tuple[agate.Table, List[Exception]]:
-        schema_map = SchemaSearchMap()
-        for relation in relations:
-            schema_map.add(relation)
-
-        with executor(self.config) as tpe:
-            futures: List[Future[agate.Table]] = []
-            for info, schemas in schema_map.items():
-                for schema in schemas:
-                    futures.append(
-                        tpe.submit_connected(
-                            self,
-                            schema,
-                            self._get_one_catalog_by_relations,
-                            info,
-                            [schema],
-                            manifest,
-                        )
-                    )
-            catalogs, exceptions = catch_as_completed(futures)
-        return catalogs, exceptions
+        if len(relations) == 0:
+            raise dbt.exceptions.CompilationError(
+                f"Expected non-empty set of relations, found " f"{relations}"
+            )
+        return self.get_catalog(manifest)
 
     def _get_one_catalog(
         self,

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -420,6 +420,10 @@ class SparkAdapter(SQLAdapter):
         manifest: Manifest,
     ) -> agate.Table:
         columns: List[Dict[str, Any]] = []
+        if len(relations) == 0:
+            raise dbt.exceptions.CompilationError(
+                "Expected at least one relation in spark _get_one_catalog_by_relations, found None"
+            )
         for relation in relations:
             logger.debug(f"Getting table schema for relation {relation}")
             columns.extend(self._get_columns_for_catalog(relation))

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -385,31 +385,30 @@ class SparkAdapter(SQLAdapter):
         self, manifest: Manifest, relations: Set[BaseRelation]
     ) -> Tuple[agate.Table, List[Exception]]:
         info_schemas = {r.information_schema() for r in relations}
-        if len(info_schemas) > 1:
+
+        if len(info_schemas) == 0:
+            return catch_as_completed([])
+
+        elif len(info_schemas) == 1:
+            info_schema = info_schemas.pop()
+            with executor(self.config) as tpe:
+                return catch_as_completed(
+                    [
+                        tpe.submit_connected(
+                            self,
+                            info_schema.identifier,
+                            self._get_one_catalog_by_relations,
+                            info_schema,
+                            relations,
+                            manifest,
+                        )
+                    ]
+                )
+
+        else:
             raise dbt.exceptions.CompilationError(
                 f"Expected only one database in get_catalog_by_relations, found {list(info_schemas)}"
             )
-        elif len(info_schemas) == 1:
-            info_schema = info_schemas.pop()
-        else:
-            raise dbt.exceptions.CompilationError(
-                "Expected a database in get_catalog_by_relations, found none"
-            )
-
-        with executor(self.config) as tpe:
-            # futures: List[Future[agate.Table]] = []
-            futures = [
-                tpe.submit_connected(
-                    self,
-                    "information_schema",
-                    self._get_one_catalog_by_relations,
-                    info_schema,
-                    relations,
-                    manifest,
-                )
-            ]
-            catalogs, exceptions = catch_as_completed(futures)
-        return catalogs, exceptions
 
     def _get_one_catalog(
         self,


### PR DESCRIPTION
resolves #900

### Problem

When `get_catalog` runs, it needs to return all relations within a schema, hence it cannot be parallelized or scale. It also means that all relations will be returned, not just those managed by dbt.

### Solution

Allow for a set of relations to be passed in to limit the query against the database.
- add _get_one_catalog_relations method
- point _get_one_catalog to this method since the second half is the same
- register that this capability is available

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX