### PR TITLE
Implementation of metadata-based freshness

### DIFF
--- a/.changes/unreleased/Features-20231219-134106.yaml
+++ b/.changes/unreleased/Features-20231219-134106.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add support for checking table-last-modified by metadata
+time: 2023-12-19T13:41:06.378573-05:00
+custom:
+  Author: mikealfare
+  Issue: "890"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: dev
 dev: ## Installs adapter in develop mode along with development dependencies
 	@\
-	pip install -e . -r requirements.txt -r dev-requirements.txt && pre-commit install
+	pip install -e .[all] -r requirements.txt -r dev-requirements.txt && pre-commit install
 
 .PHONY: dev-uninstall
 dev-uninstall: ## Uninstalls all packages while maintaining the virtual environment

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -417,7 +417,8 @@ class SparkAdapter(SQLAdapter):
         source: BaseRelation,
         manifest: Optional[Manifest] = None,
     ) -> Tuple[Optional[AdapterResponse], FreshnessResponse]:
-        path = ""
+        root = self.AdapterSpecificConfigs.location_root
+        path = f"{root}/{source.database}/{source.schema}/{source.identifier}"
         if source.is_delta:  # type: ignore
             last_modified = self._last_modified_pyspark_delta(path)
         else:

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -15,6 +15,7 @@ import dbt.exceptions
 
 from dbt.adapters.base import AdapterConfig, PythonJobHelper
 from dbt.adapters.base.impl import catch_as_completed, ConstraintSupport
+from dbt.adapters.capability import CapabilityDict, CapabilitySupport, Support, Capability
 from dbt.adapters.sql import SQLAdapter
 from dbt.adapters.spark import SparkConnectionManager
 from dbt.adapters.spark import SparkRelation
@@ -100,6 +101,12 @@ class SparkAdapter(SQLAdapter):
         ConstraintType.primary_key: ConstraintSupport.NOT_ENFORCED,
         ConstraintType.foreign_key: ConstraintSupport.NOT_ENFORCED,
     }
+
+    _capabilities: CapabilityDict = CapabilityDict(
+        {
+            Capability.TableLastModifiedMetadata: CapabilitySupport(support=Support.Full),
+        }
+    )
 
     Relation: TypeAlias = SparkRelation
     RelationInfo = Tuple[str, str, str]

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -104,7 +104,9 @@ class SparkAdapter(SQLAdapter):
 
     _capabilities: CapabilityDict = CapabilityDict(
         {
-            Capability.TableLastModifiedMetadata: CapabilitySupport(support=Support.Full),
+            Capability.TableLastModifiedMetadata: CapabilitySupport(
+                support=Support.NotImplemented
+            ),
         }
     )
 

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -104,9 +104,7 @@ class SparkAdapter(SQLAdapter):
 
     _capabilities: CapabilityDict = CapabilityDict(
         {
-            Capability.TableLastModifiedMetadata: CapabilitySupport(
-                support=Support.NotImplemented
-            ),
+            Capability.TableLastModifiedMetadata: CapabilitySupport(support=Support.Full),
         }
     )
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,7 +23,9 @@ pytest-logbook~=1.2
 pytest-xdist~=3.5
 pytz~=2023.3
 tox~=4.11
+types-python-dateutil
 types-pytz~=2023.3
+types-PyYAML
 types-requests~=2.31
 twine~=4.0
 wheel~=0.42

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,16 @@
-pyhive[hive_pure_sasl]~=0.7.0
-requests>=2.28.1
-
-pyodbc~=5.0.1
 sqlparams>=3.0.0
-thrift>=0.13.0
-sqlparse>=0.4.2 # not directly required, pinned by Snyk to avoid a vulnerability
 
-types-PyYAML
-types-python-dateutil
+# odbc extras
+pyodbc~=4.0.39
+
+# pyhive extras
+pyhive[hive_pure_sasl]~=0.7.0
+thrift>=0.11.0,<0.17.0
+
+# session extras
+delta-spark>=2.0.0,<4.0.0
+pyspark>=3.0.0,<4.0.0
+
+# not directly required, pinned by Snyk to avoid a vulnerability
+requests>=2.28.1
+sqlparse>=0.4.2

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,10 @@ pyhive_extras = [
     "PyHive[hive_pure_sasl]~=0.7.0",
     "thrift>=0.11.0,<0.17.0",
 ]
-session_extras = ["pyspark>=3.0.0,<4.0.0"]
+session_extras = [
+    "delta-spark>=2.0.0,<4.0.0",
+    "pyspark>=3.0.0,<4.0.0",
+]
 all_extras = odbc_extras + pyhive_extras + session_extras
 
 setup(

--- a/tests/functional/adapter/sources_freshness_tests/files.py
+++ b/tests/functional/adapter/sources_freshness_tests/files.py
@@ -1,0 +1,23 @@
+SCHEMA_YML = """version: 2
+sources:
+  - name: test_source
+    freshness:
+      warn_after: {count: 10, period: hour}
+      error_after: {count: 1, period: day}
+    schema: "{{ env_var('DBT_GET_LAST_RELATION_TEST_SCHEMA') }}"
+    tables:
+      - name: test_source
+"""
+
+SEED_TEST_SOURCE_CSV = """
+id,name
+1,Martin
+2,Jeter
+3,Ruth
+4,Gehrig
+5,DiMaggio
+6,Torre
+7,Mantle
+8,Berra
+9,Maris
+""".strip()

--- a/tests/functional/adapter/sources_freshness_tests/files.py
+++ b/tests/functional/adapter/sources_freshness_tests/files.py
@@ -4,6 +4,7 @@ sources:
     freshness:
       warn_after: {count: 10, period: hour}
       error_after: {count: 1, period: day}
+    schema: "{{ env_var('DBT_GET_LAST_RELATION_TEST_SCHEMA') }}"
     tables:
       - name: test_source_no_last_modified
       - name: test_source_last_modified

--- a/tests/functional/adapter/sources_freshness_tests/files.py
+++ b/tests/functional/adapter/sources_freshness_tests/files.py
@@ -4,12 +4,13 @@ sources:
     freshness:
       warn_after: {count: 10, period: hour}
       error_after: {count: 1, period: day}
-    schema: "{{ env_var('DBT_GET_LAST_RELATION_TEST_SCHEMA') }}"
     tables:
-      - name: test_source
+      - name: test_source_no_last_modified
+      - name: test_source_last_modified
+        loaded_at_field: last_modified
 """
 
-SEED_TEST_SOURCE_CSV = """
+SEED_TEST_SOURCE_NO_LAST_MODIFIED_CSV = """
 id,name
 1,Martin
 2,Jeter
@@ -20,4 +21,17 @@ id,name
 7,Mantle
 8,Berra
 9,Maris
+""".strip()
+
+SEED_TEST_SOURCE_LAST_MODIFIED_CSV = """
+id,name,last_modified
+1,Martin,2023-01-01 00:00:00
+2,Jeter,2023-02-01 00:00:00
+3,Ruth,2023-03-01 00:00:00
+4,Gehrig,2023-04-01 00:00:00
+5,DiMaggio,2023-05-01 00:00:00
+6,Torre,2023-06-01 00:00:00
+7,Mantle,2023-07-01 00:00:00
+8,Berra,2023-08-01 00:00:00
+9,Maris,2023-09-01 00:00:00
 """.strip()

--- a/tests/functional/adapter/sources_freshness_tests/test_get_relation_last_modified.py
+++ b/tests/functional/adapter/sources_freshness_tests/test_get_relation_last_modified.py
@@ -1,0 +1,30 @@
+import os
+import pytest
+
+from dbt.tests.util import run_dbt
+
+from tests.functional.adapter.sources_freshness_tests import files
+
+
+class TestGetLastRelationModified:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"test_source.csv": files.SEED_TEST_SOURCE_CSV}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"schema.yml": files.SCHEMA_YML}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, project):
+        # we need the schema name for the sources section
+        os.environ["DBT_GET_LAST_RELATION_TEST_SCHEMA"] = project.test_schema
+        run_dbt(["seed"])
+        yield
+        del os.environ["DBT_GET_LAST_RELATION_TEST_SCHEMA"]
+
+    def test_get_last_relation_modified(self, project):
+        results = run_dbt(["source", "freshness"])
+        assert len(results) == 1
+        result = results[0]
+        assert result.status == "pass"


### PR DESCRIPTION
resolves #890

### Problem

The current implementation of source freshness requires querying the data and requires the user provide a datetime field. This is slower and more expensive than it should be. It doesn't scale across multiple models. And some models do not have an appropriate datetime field.

### Solution

Use source metadata where available.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
