### PR TITLE
fix: flake8 config now properly excluding tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,4 +11,4 @@ ignore =
     E203,
     E741,
     E501,
-exclude = test
+exclude = tests


### PR DESCRIPTION
### Problem

The flake8 config is ignoring `test`, which doesn't exist

### Solution

It should ignore `tests`, or maybe the exclude line should be removed.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
