### PR TITLE
Include a pre-release in the dbt-adapters pin to allow pre-releases to be installed on main

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     install_requires=[
         "sqlparams>=3.0.0",
         "dbt-common<2.0",
-        "dbt-adapters<2.0",
+        "dbt-adapters>=0.1.0a1,<2.0",
     ],
     extras_require={
         "ODBC": odbc_extras,


### PR DESCRIPTION
### Problem

We are pinning `dbt-adapters` with only final releases, which causes `pip` to skip all pre-releases for `dbt-adapters`.

### Solution

Include a lower bound using the first pre-release on PyPI, which will allows installation of pre-releases, such as `1.0.0b1`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX