### PR TITLE
Pin `beartype<0.18.0`

### DIFF
--- a/dagger/requirements.txt
+++ b/dagger/requirements.txt
@@ -1,2 +1,3 @@
 dagger-io~=0.9.7
 python-dotenv
+beartype<0.18.0

--- a/dagger/requirements.txt
+++ b/dagger/requirements.txt
@@ -1,3 +1,3 @@
+beartype<0.18.0
 dagger-io~=0.9.7
 python-dotenv
-beartype<0.18.0


### PR DESCRIPTION
resolves https://github.com/dbt-labs/adapters-team-private/issues/120

### Problem

`dagger` has a regression due to `beartype`.

### Solution

Pin `beartype<0.18.0` for now, until `dagger` does the same and publishes.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
