### PR TITLE
Add `dbt-core~=1.8.0a1` as convenience dep

### DIFF
--- a/.changes/unreleased/Dependencies-20240403-135436.yaml
+++ b/.changes/unreleased/Dependencies-20240403-135436.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Add `dbt-core` as a dependency to preserve backwards compatibility for installation
+time: 2024-04-03T13:54:36.667724-04:00
+custom:
+  Author: mikealfare
+  PR: "1002"

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,8 @@ setup(
         "sqlparams>=3.0.0",
         "dbt-common>=0.1.0a1,<2.0",
         "dbt-adapters>=0.1.0a1,<2.0",
+        # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
+        "dbt-core>=1.8.0a1",
     ],
     extras_require={
         "ODBC": odbc_extras,


### PR DESCRIPTION
### Problem

We need to preserve backwards compatibility for installing this package.

### Solution

Include `dbt-core` as a dependency for installation, but do not depend on it within functional code.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX