### PR TITLE
[Backport 1.4.latest] Pin `macos` runners to `macos-12` (#1016)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,7 +174,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:


### PR DESCRIPTION
(cherry picked from commit c5742f225f20938f16c4ce95ba7e71d6874a198c)

Backport #1016