### PR TITLE
Skip tests on `main` to unblock CI, create issues to fix them

### DIFF
--- a/tests/functional/adapter/test_constraints.py
+++ b/tests/functional/adapter/test_constraints.py
@@ -358,6 +358,17 @@ class TestSparkIncrementalConstraintsRollback(
             "constraints_schema.yml": constraints_yml,
         }
 
+    @pytest.mark.skip(
+        "Databricks now raises an exception, which gets raised prior to the `expected_pass` check."
+        "See https://github.com/dbt-labs/dbt-spark/issues/1009"
+    )
+    def test__constraints_enforcement_rollback(
+        self, project, expected_color, expected_error_messages, null_model_sql
+    ):
+        super().test__constraints_enforcement_rollback(
+            project, expected_color, expected_error_messages, null_model_sql
+        )
+
 
 # TODO: Like the tests above, this does test that model-level constraints don't
 # result in errors, but it does not verify that they are actually present in

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -24,6 +24,13 @@ class TestPythonIncrementalModelSpark(BasePythonIncrementalTests):
     def project_config_update(self):
         return {}
 
+    @pytest.mark.skip(
+        "Databricks can't find the transaction log"
+        "See https://github.com/dbt-labs/dbt-spark/issues/1033"
+    )
+    def test_incremental(self, project):
+        super().test_incremental(project)
+
 
 models__simple_python_model = """
 import pandas


### PR DESCRIPTION
### Problem

Two tests are consistently failing on `main`, which prevents CI from completing.

### Solution

- create an issue for each test
  - #1009
  - #1033
- skip the test
- reference the issue in the skip
- resolve the failed tests according to priority

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
