### PR TITLE
[Bug] Fix constraints enforcement rollover test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyhive[hive_pure_sasl]~=0.7.0
 requests>=2.28.1
 
-pyodbc~=5.0.1
+pyodbc~=5.0.1 --no-binary pyodbc
 sqlparams>=3.0.0
 thrift>=0.13.0
 sqlparse>=0.4.2 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/test.env.example
+++ b/test.env.example
@@ -1,13 +1,9 @@
-# Cluster ID
-DBT_DATABRICKS_CLUSTER_NAME=
-# SQL Endpoint
-DBT_DATABRICKS_ENDPOINT=
-# Server Hostname value
-DBT_DATABRICKS_HOST_NAME=
-# personal token
-DBT_DATABRICKS_TOKEN=
-# file path to local ODBC driver
-ODBC_DRIVER=
+# databricks credentials
+DBT_DATABRICKS_HOST_NAME=<{this value}.cloud.databricks.com>.cloud.databricks.com
+DBT_DATABRICKS_TOKEN=<personal token>
+DBT_DATABRICKS_CLUSTER_NAME=<sql/protocolv1/o/{not this}/{this value}>
+ODBC_DRIVER=</file/path/to/local/ODBC.driver>
+DBT_DATABRICKS_ENDPOINT=</sql/1.0/warehouses/{this value}>
 
 # users for testing 'grants' functionality
 DBT_TEST_USER_1=

--- a/tests/functional/adapter/test_constraints.py
+++ b/tests/functional/adapter/test_constraints.py
@@ -358,10 +358,6 @@ class TestSparkIncrementalConstraintsRollback(
             "constraints_schema.yml": constraints_yml,
         }
 
-    @pytest.mark.skip(
-        "Databricks now raises an exception, which gets raised prior to the `expected_pass` check."
-        "See https://github.com/dbt-labs/dbt-spark/issues/1009"
-    )
     def test__constraints_enforcement_rollback(
         self, project, expected_color, expected_error_messages, null_model_sql
     ):

--- a/tests/functional/adapter/test_constraints.py
+++ b/tests/functional/adapter/test_constraints.py
@@ -358,13 +358,6 @@ class TestSparkIncrementalConstraintsRollback(
             "constraints_schema.yml": constraints_yml,
         }
 
-    def test__constraints_enforcement_rollback(
-        self, project, expected_color, expected_error_messages, null_model_sql
-    ):
-        super().test__constraints_enforcement_rollback(
-            project, expected_color, expected_error_messages, null_model_sql
-        )
-
 
 # TODO: Like the tests above, this does test that model-level constraints don't
 # result in errors, but it does not verify that they are actually present in

--- a/tests/functional/adapter/test_constraints.py
+++ b/tests/functional/adapter/test_constraints.py
@@ -316,7 +316,7 @@ class BaseSparkConstraintsRollbackSetup:
             "violate the new NOT NULL constraint",
             "(id > 0) violated by row with values:",  # incremental mats
             "DELTA_VIOLATE_CONSTRAINT_WITH_VALUES",  # incremental mats
-            "NOT NULL constraint violated for column",
+            "NOT NULL constraint violated for col",
         ]
 
     def assert_expected_error_messages(self, error_message, expected_error_messages):


### PR DESCRIPTION
resolves #1009

### Problem

This test started failing. We skipped it to release and need to address the failure. We suspect there was a change with delta tables in Databricks that we're not properly accounting for.

### Solution

- unskip the test
- update expected error messages to allow for ubuntu and macos versions

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
