### PR TITLE
Bump deps on common, adapters, core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,10 +65,10 @@ setup(
     include_package_data=True,
     install_requires=[
         "sqlparams>=3.0.0",
-        "dbt-common>=0.1.0a1,<2.0",
-        "dbt-adapters>=0.1.0a1,<2.0",
+        "dbt-common>=1.0.4,<2.0",
+        "dbt-adapters>=1.1.1,<2.0",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-        "dbt-core>=1.8.0a1",
+        "dbt-core>=1.8.0",
     ],
     extras_require={
         "ODBC": odbc_extras,


### PR DESCRIPTION
Bump requirements to:
- `"dbt-common>=1.0.4,<2.0"`
- `"dbt-adapters>=1.1.1,<2.0"`
- `"dbt-core>=1.8.0"`

This way, if someone runs `pip install dbt-spark` with an existing (v1.8 prerelease) install of the other packages, they won't end up with incompatible package versions.