### PR TITLE
Adap 1049/lazy load agate

### DIFF
--- a/.changes/unreleased/Under the Hood-20240612-195629.yaml
+++ b/.changes/unreleased/Under the Hood-20240612-195629.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Lazy load agate to improve performance
+time: 2024-06-12T19:56:29.943204-07:00
+custom:
+  Author: versusfacit
+  Issue: "1049"


### PR DESCRIPTION
resolves #1049

### Problem

Let's lazy load Agate and make it available for type checking.

### Solution

Propagates the lazy load paradigm from other adapter PRs.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
