### PR TITLE
Remove unused test dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,16 +9,11 @@ git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 ipdb~=0.13.13
 pre-commit~=3.7.0;python_version>="3.9"
 pre-commit~=3.5.0;python_version<"3.9"
-
-# test
-freezegun~=1.4
-mock~=5.1
 pytest~=7.4
 pytest-csv~=3.0
 pytest-dotenv~=0.5.2
 pytest-logbook~=1.2
 pytest-xdist~=3.6
-thrift_sasl~=0.4.3
 
 # build
 bumpversion~=0.6.0


### PR DESCRIPTION
### Problem

We don't use these test dependencies even though we declare them.

### Solution

Remove them.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
