### PR TITLE
Update `standardize_grants_dict` to handle potential case mismatches in grants table response

### DIFF
--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -496,11 +496,24 @@ class SparkAdapter(SQLAdapter):
         }
 
     def standardize_grants_dict(self, grants_table: "agate.Table") -> dict:
+        def get_cased_column_name_for_column(tuple_data: Tuple[str], column_name: str) -> str:
+            for item in tuple_data:
+                if item.lower() == column_name.lower():
+                    return item
+            raise DbtRuntimeError(
+                f'Column "{column_name}" not found in grants table columns `{', '.join(grants_table.column_names)}`.'
+            )
+        
+        column_names = grants_table.column_names
+        principal_column_name = get_cased_column_name_for_column(column_names, "Principal")
+        privilege_column_name = get_cased_column_name_for_column(column_names, "ActionType")
+        object_type_column_name = get_cased_column_name_for_column(column_names, "ObjectType")
+
         grants_dict: Dict[str, List[str]] = {}
         for row in grants_table:
-            grantee = row["Principal"]
-            privilege = row["ActionType"]
-            object_type = row["ObjectType"]
+            grantee = row[principal_column_name]
+            privilege = row[privilege_column_name]
+            object_type = row[object_type_column_name]
 
             # we only want to consider grants on this object
             # (view or table both appear as 'TABLE')


### PR DESCRIPTION
Match case to column names returned rather than hardcoding.
Fixes: #1086

resolves #1086
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

DBT crashing due to column case mismatch in response from databricks on `show grants` statement.

### Solution

Match column name case to response rather than hardcoding names.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
