### PR TITLE
Enable setting dbt_valid_to snapshot column to new setting dbt_valid_to_current

### DIFF
--- a/.changes/unreleased/Features-20240927-133927.yaml
+++ b/.changes/unreleased/Features-20240927-133927.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Enable setting current value of dbt_valid_to
+time: 2024-09-27T13:39:27.268886-04:00
+custom:
+  Author: gshank
+  Issue: "1112"

--- a/dbt/include/spark/macros/materializations/snapshot.sql
+++ b/dbt/include/spark/macros/materializations/snapshot.sql
@@ -24,7 +24,11 @@
     {% endif %}
     on DBT_INTERNAL_SOURCE.{{ columns.dbt_scd_id }} = DBT_INTERNAL_DEST.{{ columns.dbt_scd_id }}
     when matched
-     and DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} is null
+     {% if config.get("dbt_valid_to_current") %}
+       and DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} = {{ config.get('dbt_valid_to_current') }}
+     {% else %}
+       and DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} is null
+     {% endif %}
      and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')
         then update
         set {{ columns.dbt_valid_to }} = DBT_INTERNAL_SOURCE.{{ columns.dbt_valid_to }}

--- a/dbt/include/spark/macros/materializations/snapshot.sql
+++ b/dbt/include/spark/macros/materializations/snapshot.sql
@@ -25,7 +25,8 @@
     on DBT_INTERNAL_SOURCE.{{ columns.dbt_scd_id }} = DBT_INTERNAL_DEST.{{ columns.dbt_scd_id }}
     when matched
      {% if config.get("dbt_valid_to_current") %}
-       and DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} = {{ config.get('dbt_valid_to_current') }}
+       and ( DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} = {{ config.get('dbt_valid_to_current') }} or
+             DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} is null )
      {% else %}
        and DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} is null
      {% endif %}

--- a/tests/functional/adapter/persist_docs/test_persist_docs.py
+++ b/tests/functional/adapter/persist_docs/test_persist_docs.py
@@ -15,7 +15,7 @@ from fixtures import (
 )
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session", "databricks_cluster")
+@pytest.mark.skip_profile("apache_spark", "spark_session")
 class TestPersistDocsDeltaTable:
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/functional/adapter/persist_docs/test_persist_docs.py
+++ b/tests/functional/adapter/persist_docs/test_persist_docs.py
@@ -120,7 +120,7 @@ class TestPersistDocsDeltaView:
                 assert result[2] is None
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_http_odbc")
+@pytest.mark.skip_profile("apache_spark", "spark_session")
 class TestPersistDocsMissingColumn:
     @pytest.fixture(scope="class")
     def project_config_update(self):

--- a/tests/functional/adapter/persist_docs/test_persist_docs.py
+++ b/tests/functional/adapter/persist_docs/test_persist_docs.py
@@ -15,7 +15,7 @@ from fixtures import (
 )
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "databricks_cluster")
 class TestPersistDocsDeltaTable:
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/functional/adapter/persist_docs/test_persist_docs.py
+++ b/tests/functional/adapter/persist_docs/test_persist_docs.py
@@ -120,7 +120,7 @@ class TestPersistDocsDeltaView:
                 assert result[2] is None
 
 
-@pytest.mark.skip_profile("apache_spark", "spark_session")
+@pytest.mark.skip_profile("apache_spark", "spark_session", "spark_http_odbc")
 class TestPersistDocsMissingColumn:
     @pytest.fixture(scope="class")
     def project_config_update(self):

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -89,7 +89,7 @@ def model(dbt, spark):
     "spark_session",
     "databricks_sql_endpoint",
     "spark_http_odbc",
-    "databricks_http_cluster",
+    "databricks_cluster",
 )
 class TestChangingSchemaSpark:
     """

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -85,7 +85,11 @@ def model(dbt, spark):
 
 
 @pytest.mark.skip_profile(
-    "apache_spark", "spark_session", "databricks_sql_endpoint", "spark_http_odbc"
+    "apache_spark",
+    "spark_session",
+    "databricks_sql_endpoint",
+    "spark_http_odbc",
+    "databricks_http_cluster",
 )
 class TestChangingSchemaSpark:
     """

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -89,7 +89,7 @@ def model(dbt, spark):
     "spark_session",
     "databricks_sql_endpoint",
     "spark_http_odbc",
-    "databricks_cluster",
+    "databricks_http_cluster",
 )
 class TestChangingSchemaSpark:
     """


### PR DESCRIPTION
resolves #1112

### Problem

Support work being done in dbt-core and dbt-adapters to enable setting the value of a current row in the dbt_valid_to column.

Support dbt-core https://github.com/dbt-core/issue/10187, dbt-adapters https://github.com/dbt-labs/dbt-adapters/pull/321.

### Solution

Use the "dbt_valid_to_current" config.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
