### PR TITLE
[Bug 1.8.latest] Pin build dependencies to final releases

### DIFF
--- a/.changes/unreleased/Fixes-20241023-105407.yaml
+++ b/.changes/unreleased/Fixes-20241023-105407.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Pin build dependencies to final releases
+time: 2024-10-23T10:54:07.142933-04:00
+custom:
+  Author: mikealfare
+  Issue: "1129"

--- a/setup.py
+++ b/setup.py
@@ -65,10 +65,10 @@ setup(
     include_package_data=True,
     install_requires=[
         "sqlparams>=3.0.0",
-        "dbt-common>=0.1.0a1,<2.0",
-        "dbt-adapters>=0.1.0a1,<2.0",
+        "dbt-common>=0.1.0,<2.0",
+        "dbt-adapters>=0.1.0,<2.0",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-        "dbt-core>=1.8.0a1",
+        "dbt-core>=1.8.0",
     ],
     extras_require={
         "ODBC": odbc_extras,

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -53,7 +53,7 @@ def model(dbt, spark):
                 "ResourceClass": "SingleNode"
             }
         },
-        packages=['spacy', 'torch', 'pydantic>=1.10.8', 'numpy<2']
+        packages=['spacy', 'torch', 'pydantic<1.10.3', 'numpy<1.2']
     )
     data = [[1,2]] * 10
     return spark.createDataFrame(data, schema=['test', 'test2'])

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -5,7 +5,12 @@ from dbt.tests.adapter.python_model.test_python_model import (
     BasePythonModelTests,
     BasePythonIncrementalTests,
 )
-from dbt.tests.adapter.python_model.test_spark import BasePySparkTests
+from dbt.tests.adapter.python_model.test_spark import (
+    BasePySparkTests,
+    PANDAS_MODEL,
+    PANDAS_ON_SPARK_MODEL,
+    PYSPARK_MODEL,
+)
 
 
 @pytest.mark.skip_profile("apache_spark", "spark_session", "databricks_sql_endpoint")
@@ -15,7 +20,13 @@ class TestPythonModelSpark(BasePythonModelTests):
 
 @pytest.mark.skip_profile("apache_spark", "spark_session", "databricks_sql_endpoint")
 class TestPySpark(BasePySparkTests):
-    pass
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "pandas_df.py": PANDAS_MODEL,
+            "pyspark_df.py": PYSPARK_MODEL,
+            "pandas_on_spark_df.py": PANDAS_ON_SPARK_MODEL,
+        }
 
 
 @pytest.mark.skip_profile("apache_spark", "spark_session", "databricks_sql_endpoint")
@@ -53,7 +64,7 @@ def model(dbt, spark):
                 "ResourceClass": "SingleNode"
             }
         },
-        packages=['spacy', 'torch', 'pydantic<1.10.3', 'numpy<1.20']
+        packages=['spacy', 'torch', 'pydantic<1.10.3']
     )
     data = [[1,2]] * 10
     return spark.createDataFrame(data, schema=['test', 'test2'])

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -53,7 +53,7 @@ def model(dbt, spark):
                 "ResourceClass": "SingleNode"
             }
         },
-        packages=['spacy', 'torch', 'pydantic<1.10.3', 'numpy<1.2']
+        packages=['spacy', 'torch', 'pydantic<1.10.3', 'numpy<1.20']
     )
     data = [[1,2]] * 10
     return spark.createDataFrame(data, schema=['test', 'test2'])

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -53,7 +53,7 @@ def model(dbt, spark):
                 "ResourceClass": "SingleNode"
             }
         },
-        packages=['spacy', 'torch', 'pydantic<1.10.3']
+        packages=['spacy', 'torch', 'pydantic>=1.10.8', 'numpy<2']
     )
     data = [[1,2]] * 10
     return spark.createDataFrame(data, schema=['test', 'test2'])


### PR DESCRIPTION
### Problem

We never updated pins to final releases when we cut the `1.8.latest` release branch.

### Solution

Update pins for `dbt-common`, `dbt-adapters`, and `dbt-core`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX