### PR TITLE
move github runner from macos-12 to macos-14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,7 +172,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         dist-type: ["whl", "gz"]
 


### PR DESCRIPTION
### Problem

The `macos-12` runner is deprecated. `macos-14` is now `macos-latest`.

### Solution

Upgrade to `macos-14` for our runners.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
