### PR TITLE
fix: Do not require alias to avoid duplicate aliasing with `--empty`

### DIFF
--- a/.changes/unreleased/Fixes-20241214-101933.yaml
+++ b/.changes/unreleased/Fixes-20241214-101933.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Stop adding aliases to render_limited output
+time: 2024-12-14T10:19:33.470916-07:00
+custom:
+    Author: anaghshineh
+    Issue: "1098"

--- a/dbt/adapters/spark/relation.py
+++ b/dbt/adapters/spark/relation.py
@@ -35,6 +35,7 @@ class SparkRelation(BaseRelation):
     is_iceberg: Optional[bool] = None
     # TODO: make this a dict everywhere
     information: Optional[str] = None
+    require_alias: bool = False
 
     def __post_init__(self) -> None:
         if self.database != self.schema and self.database:

--- a/tests/functional/adapter/empty/test_empty.py
+++ b/tests/functional/adapter/empty/test_empty.py
@@ -1,5 +1,9 @@
-from dbt.tests.adapter.empty.test_empty import BaseTestEmpty
+from dbt.tests.adapter.empty.test_empty import BaseTestEmpty, BaseTestEmptyInlineSourceRef
 
 
 class TestSparkEmpty(BaseTestEmpty):
+    pass
+
+
+class TestSparkEmptyInlineSourceRef(BaseTestEmptyInlineSourceRef):
     pass


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-adapters/issues/474
docs N/A

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

When running a dry run via `--empty`, dbt would duplicate any model aliases, causing the query to fail due to invalid syntax.

### Solution

This PR adopts the approaches taken in other adapters that do not require aliasing. Namely, it overrides the default `True` value for `require_alias`, setting it to `False`. As a result, when dbt creates dynamic SQL for dry runs, it does not inject additional aliasing. Thus, if a reference uses an alias, it keeps it as is. If not, it does not inject anything.

I also imported the `BaseTestEmptyInlineSourceRef` from `dbt-adapters` to run those additional tests. Please let me know if you'd like to see additional testing done for this PR!

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
